### PR TITLE
YG-39 [feat]: editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,46 +177,88 @@ deploy
 
 <h3>Stacks</h3>
 
-<h4>Languages</h4>
+<table>
+  <tr>
+    <td><h4>Languages</h4></td>
+    <td>
+      <img src="https://img.shields.io/badge/HTML5-E34F26?style=flat-square&logo=html5&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/CSS3-1572B6?style=flat-square&logo=css3&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white">
+    </td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><h4>Framework</h4></td>
+    <td>
+      <img src="https://img.shields.io/badge/next.js-000?style=flat-square&logo=next.js&logoColor=white">
+    </td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><h4>Library</h4></td>
+    <td>
+      <img src="https://img.shields.io/badge/nextUI-000?style=flat-square&logo=nextui&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/tailwindcss-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/zod-3E67B1?style=flat-square&logo=zod&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/reactquery-FF4154?style=flat-square&logo=reactquery&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/storybook-FF4785?style=flat-square&logo=storybook&logoColor=white">
+    </td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><h4>Communications</h4></td>
+    <td>
+      <img src="https://img.shields.io/badge/GitHub-000000?style=flat-square&logo=github&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/discord-5865F2?style=flat-square&logo=discord&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/jira-0052CC?style=flat-square&logo=jira&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/notion-000000?style=flat-square&logo=notion&logoColor=white">
+    </td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td><h4>Tools</h4></td>
+    <td>
+      <img src="https://img.shields.io/badge/figma-F24E1E?style=flat-square&logo=figma&logoColor=white"> 
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/Visual%20Studio%20Code-007ACC?style=flat-square&logo=Visual%20Studio%20Code&logoColor=white">
+    </td>
+    <td>
+      <img src="https://img.shields.io/badge/NPM-CB3837?style=flat-square&logo=npm&logoColor=white">
+    </td>
+    <td></td>
+    <td></td>
+    <td></td>
+  </tr>
+</table>
 
-<p align="center">
-<img src="https://img.shields.io/badge/HTML5-E34F26?style=flat-square&logo=html5&logoColor=white">
-<img src="https://img.shields.io/badge/CSS3-1572B6?style=flat-square&logo=css3cript&logoColor=white">
-<img src="https://img.shields.io/badge/TypeScript-3178C6?style=flat-square&logo=typescript&logoColor=white">
-</p>
 
-<h4>Framework</h4>
 
-<p align="center">
-<img src="https://img.shields.io/badge/nextjs-000?style=flat-square&logo=nextjs&logoColor=white">
-</p>
-
-<h4>Library</h4>
-
-<p align="center">
-<img src="https://img.shields.io/badge/nextUI-000?style=flat-square&logo=nextui&logoColor=white">
-<img src="https://img.shields.io/badge/tailwindcss-06B6D4?style=flat-square&logo=tailwindcss&logoColor=white">
-<img src="https://img.shields.io/badge/zod-3E67B1?style=flat-square&logo=zod&logoColor=white">
-<img src="https://img.shields.io/badge/reactquery-FF4154?style=flat-square&logo=reactquery&logoColor=white">
-<img src="https://img.shields.io/badge/storybook-FF4785?style=flat-square&logo=storybook&logoColor=white">
-</p>
-
-<h4>Communications</h4>
-
-<p align="center">
-<img src="https://img.shields.io/badge/GitHub-000000?style=flat-square&logo=github&logoColor=white">
-<img src="https://img.shields.io/badge/discord-5865F2?style=flat-square&logo=discord&logoColor=white">
-<img src="https://img.shields.io/badge/jira-0052CC?style=flat-square&logo=jira&logoColor=white">
-<img src="https://img.shields.io/badge/notion-000000?style=flat-square&logo=notion&logoColor=white">
-</p>
-
-<h4>Tools</h4>
-
-<p align="center">
-<img src="https://img.shields.io/badge/figma-F24E1E?style=flat-square&logo=figma&logoColor=white"> 
-<img src="https://img.shields.io/badge/Visual%20Studio%20Code-007ACC.svg?&style=for-the-badge&logo=Visual%10Studio%10Code&logoColor=white">
-<img src="https://img.shields.io/badge/NPM-CB3837?style=flat-square&logo=npm&logoColor=white">
-</p>
 
 <br/>
 <br/>

--- a/app/(afterLogin)/createPost/_components/editorQuill.tsx
+++ b/app/(afterLogin)/createPost/_components/editorQuill.tsx
@@ -8,12 +8,17 @@ const ReactQuill = dynamic(() => import("react-quill"), { ssr: false })
 export const QuillEditor = () => {
     return (
         <ReactQuill
+            className="quill-editor"
             modules={{
                 toolbar: [
-                    [{ header: [1, 2, false] }],
                     ["bold", "italic", "underline", "strike", "blockquote"],
+                    [{ header: [1, 2, 3, 4, 5, 6, false] }],
+                    [{ font: [] }],
+                    [{ direction: "rtl" }],
+                    ["image", "link"],
                     [{ list: "ordered" }, { list: "bullet" }],
-                    ["link", "image"],
+                    [{ color: [] }, { background: [] }], // dropdown with defaults from theme
+                    [{ align: [] }],
                     ["clean"],
                 ],
             }}

--- a/app/(afterLogin)/createPost/_components/editorQuill.tsx
+++ b/app/(afterLogin)/createPost/_components/editorQuill.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import dynamic from "next/dynamic"
+import "react-quill/dist/quill.snow.css"
+
+const ReactQuill = dynamic(() => import("react-quill"), { ssr: false })
+
+export const QuillEditor = () => {
+    return (
+        <ReactQuill
+            modules={{
+                toolbar: [
+                    [{ header: [1, 2, false] }],
+                    ["bold", "italic", "underline", "strike", "blockquote"],
+                    [{ list: "ordered" }, { list: "bullet" }],
+                    ["link", "image"],
+                    ["clean"],
+                ],
+            }}
+        />
+    )
+}

--- a/app/(afterLogin)/freeForm/page.tsx
+++ b/app/(afterLogin)/freeForm/page.tsx
@@ -1,4 +1,11 @@
+import { QuillEditor } from "../createPost/_components/editorQuill"
+
 const Page = () => {
-    return <div>Free Form</div>
+    return (
+        <div>
+            <p>Free Form</p>
+            <QuillEditor />
+        </div>
+    )
 }
 export default Page

--- a/app/globals.css
+++ b/app/globals.css
@@ -21,11 +21,15 @@ body {
 }
 
 .quill-editor .ql-snow {
-  @apply border-none !important;
+  @apply border-none h-[80px] flex justify-center items-center !important;
 }
 
 .quill-editor .ql-editor {
   @apply border-none min-h-[200px];
+}
+
+.quill-editor .ql-container {
+  @apply absolute top-[19%] left-0 w-[900px] min-h-[200px] bg-SYSTEM-white rounded-xl !important;
 }
 
 @layer utilities {

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,18 @@ body {
   @apply bg-SYSTEM-beige;
 }
 
+.quill-editor {
+  @apply bg-SYSTEM-white w-[900px] border-0 rounded-xl;
+}
+
+.quill-editor .ql-snow {
+  @apply border-none !important;
+}
+
+.quill-editor .ql-editor {
+  @apply border-none min-h-[200px];
+}
+
 @layer utilities {
   .text-balance {
     text-wrap: balance;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
                 "react": "^18",
                 "react-dom": "^18",
                 "react-hook-form": "^7.51.5",
+                "react-quill": "^2.0.0",
                 "tailwind-merge": "^2.3.0",
                 "zod": "^3.23.8",
                 "zustand": "^4.5.2"
@@ -521,6 +522,14 @@
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
             "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
             "devOptional": true
+        },
+        "node_modules/@types/quill": {
+            "version": "1.3.10",
+            "resolved": "https://registry.npmjs.org/@types/quill/-/quill-1.3.10.tgz",
+            "integrity": "sha512-IhW3fPW+bkt9MLNlycw8u8fWb7oO7W5URC9MfZYHBlA24rex9rs23D5DETChu1zvgVdc5ka64ICjJOgQMr6Shw==",
+            "dependencies": {
+                "parchment": "^1.1.2"
+            }
         },
         "node_modules/@types/react": {
             "version": "18.3.3",
@@ -1119,7 +1128,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
             "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-            "dev": true,
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -1246,6 +1254,14 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
             "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+        },
+        "node_modules/clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+            "engines": {
+                "node": ">=0.8"
+            }
         },
         "node_modules/clsx": {
             "version": "2.1.1",
@@ -1400,6 +1416,25 @@
                 }
             }
         },
+        "node_modules/deep-equal": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.2.tgz",
+            "integrity": "sha512-5tdhKF6DbU7iIzrIOa1AOUt39ZRm13cmL1cGEh//aqR8x9+tNfbywRf0n5FD/18OKMdo7DNEtrX2t22ZAkI+eg==",
+            "dependencies": {
+                "is-arguments": "^1.1.1",
+                "is-date-object": "^1.0.5",
+                "is-regex": "^1.1.4",
+                "object-is": "^1.1.5",
+                "object-keys": "^1.1.1",
+                "regexp.prototype.flags": "^1.5.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1410,7 +1445,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-            "dev": true,
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -1427,7 +1461,6 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-            "dev": true,
             "dependencies": {
                 "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
@@ -1574,7 +1607,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
             "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-            "dev": true,
             "dependencies": {
                 "get-intrinsic": "^1.2.4"
             },
@@ -1586,7 +1618,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -2261,6 +2292,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.3.tgz",
+            "integrity": "sha512-jLN68Dx5kyFHaePoXWPsCGW5qdyZQtLYHkxkg02/Mz6g0kYpDx4FyP6XfArhQdlOC4b8Mv+EMxPo/8La7Tzghg=="
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2431,7 +2472,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -2458,7 +2498,6 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -2467,7 +2506,6 @@
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
             "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2",
@@ -2624,7 +2662,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
             "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-            "dev": true,
             "dependencies": {
                 "get-intrinsic": "^1.1.3"
             },
@@ -2665,7 +2702,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-            "dev": true,
             "dependencies": {
                 "es-define-property": "^1.0.0"
             },
@@ -2677,7 +2713,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
             "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2689,7 +2724,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
             "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -2701,7 +2735,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dev": true,
             "dependencies": {
                 "has-symbols": "^1.0.3"
             },
@@ -2716,7 +2749,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -2802,6 +2834,21 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-array-buffer": {
@@ -2918,7 +2965,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
             "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-            "dev": true,
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
             },
@@ -3047,7 +3093,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
             "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
                 "has-tostringtag": "^1.0.0"
@@ -3355,6 +3400,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -3585,11 +3635,25 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/object-is": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -3747,6 +3811,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/parchment": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/parchment/-/parchment-1.1.4.tgz",
+            "integrity": "sha512-J5FBQt/pM2inLzg4hEWmzQx/8h8D0CiDxaG3vyp9rKrQRSDgBlhjdP5jQGgosEajXPSQouXGHOmVdgo7QmJuOg=="
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -4087,6 +4156,37 @@
                 }
             ]
         },
+        "node_modules/quill": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+            "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
+            "dependencies": {
+                "clone": "^2.1.1",
+                "deep-equal": "^1.0.1",
+                "eventemitter3": "^2.0.3",
+                "extend": "^3.0.2",
+                "parchment": "^1.1.4",
+                "quill-delta": "^3.6.2"
+            }
+        },
+        "node_modules/quill-delta": {
+            "version": "3.6.3",
+            "resolved": "https://registry.npmjs.org/quill-delta/-/quill-delta-3.6.3.tgz",
+            "integrity": "sha512-wdIGBlcX13tCHOXGMVnnTVFtGRLoP0imqxM696fIPwIf5ODIYUHIvHbZcyvGlZFiFhK5XzDC2lpjbxRhnM05Tg==",
+            "dependencies": {
+                "deep-equal": "^1.0.1",
+                "extend": "^3.0.2",
+                "fast-diff": "1.1.2"
+            },
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/quill-delta/node_modules/fast-diff": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+            "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig=="
+        },
         "node_modules/react": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4130,6 +4230,20 @@
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
             "dev": true
+        },
+        "node_modules/react-quill": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/react-quill/-/react-quill-2.0.0.tgz",
+            "integrity": "sha512-4qQtv1FtCfLgoD3PXAur5RyxuUbPXQGOHgTlFie3jtxp43mXDtzCKaOgQ3mLyZfi1PUlyjycfivKelFhy13QUg==",
+            "dependencies": {
+                "@types/quill": "^1.3.10",
+                "lodash": "^4.17.4",
+                "quill": "^1.3.7"
+            },
+            "peerDependencies": {
+                "react": "^16 || ^17 || ^18",
+                "react-dom": "^16 || ^17 || ^18"
+            }
         },
         "node_modules/read-cache": {
             "version": "1.0.0",
@@ -4182,7 +4296,6 @@
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz",
             "integrity": "sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==",
-            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.6",
                 "define-properties": "^1.2.1",
@@ -4360,7 +4473,6 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-            "dev": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -4377,7 +4489,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
             "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "dev": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.51.5",
+        "react-quill": "^2.0.0",
         "tailwind-merge": "^2.3.0",
         "zod": "^3.23.8",
         "zustand": "^4.5.2"


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->
게시글 작성을 위한 에디터 설치했습니다.

[YG-39 #open #comment 🟢 quill 컴포넌트](https://github.com/mobi-projects/yeogi-client/commit/2b8446aa540c0cef9cd11e5f591c539f8ada2ec2)
[YG-39 #close #comment 🟢 quill 컴포넌트 옵션 및 스타일 적용](https://github.com/mobi-projects/yeogi-client/commit/2247a1a64263b4ebd563a424441eb9c85def63c1)
[YG-39 #close #comment 🎁 디테일한 스타일 조정](https://github.com/mobi-projects/yeogi-client/pull/27/commits/8764d8ee7df9a73d84459a41a0560903b9500b28)

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->


저희가 사용하기로 한 에디터는 [react-quill](https://quilljs.com/docs/why-quill) 이었습니다.

### Why Quill ?

next.js에서 사용할 수 있는 에디터 관련 라이브러리로는 대표적으로  Draft.js, Slate.js, Quill.js, CKEditor 등이 있습니다.
그 중 quill을 사용한 이유는 아래와 같이 정리할 수 있습니다.

<br />

1️⃣ 간편한 사용성
Quill은 사용하기 쉽고 직관적인 API를 제공합니다. 
React와의 통합이 잘 되어 있어서 React 애플리케이션에서 쉽게 사용할 수 있습니다.

2️⃣ 커스터마이징
uill은 많은 커스터마이징 옵션을 제공합니다. 
에디터의 외관 및 동작을 필요에 맞게 조정할 수 있습니다.

3️⃣ 풍부한 기능
Quill은 텍스트 편집을 위한 다양한 기능을 제공합니다. 
텍스트 서식 지정, 이미지 및 동영상 삽입, 텍스트 스타일링 등을 포함합니다.

4️⃣ 커뮤니티 및 문서
Quill은 활발한 커뮤니티와 잘 작성된 문서를 가지고 있어서 문제 발생 시 해결하기 쉽습니다. 
또한 다양한 플러그인이 존재하여 필요에 맞게 확장할 수 있습니다.

5️⃣ 성능
Quill은 빠른 렌더링 및 사용자 경험을 위해 최적화되어 있습니다.

<br />

### How to use Quill...

공식문서 → 🔗 https://quilljs.com/docs/quickstart

<br />

editorQuill 이라는 파일로 분리했으니 게시글 작성하는 파일에서 해당 에디터를 import 해 사용하시면 됩니다.
editorQuill을 사용하면서 발생하는 문제들은 다른 개발자들의 깃 이슈 목록을 살펴 보는 것을 추천드립니다.

react-quill issues → 🔗 https://github.com/zenoamaro/react-quill/issues

<br />

```javascript
"use client"

import dynamic from "next/dynamic"
import "react-quill/dist/quill.snow.css"

const ReactQuill = dynamic(() => import("react-quill"), { ssr: false })

export const QuillEditor = () => {
    return (
        <ReactQuill className="quill-editor" modules={{toolbar: [ "toolbar에 들어갈 기능들"] }}  />
    )
}
```

<br />

### dynamic import

react-quill issue : 
- [Server-Side Rendering (SSR), NextJS, etc.](https://github.com/zenoamaro/react-quill/issues/919)
- [ReactQuill component not appearing in NextJS 13.4.2](https://github.com/zenoamaro/react-quill/issues/897)

quill-editor 자체가 SSR에서 불러와 사용할 수 없는 모듈이었기 때문에 해당 컴포넌트 자체를 동적으로 가져오도록 설정하는 것이 대부분이었습니다. 이유를 검색해보니 아래와 같이 정리할 수 있었어요. 참고하시면 좋을 것 같습니다. 🙂

<br />

1️⃣ 번들 크기 최적화

Quill은 꽤 큰 라이브러리이기 때문에 애플리케이션의 초기 로딩 시간을 줄이기 위해 필요할 때만 동적으로 로드하는 것이 유용합니다. 
이렇게 하면 사용자가 페이지를 방문할 때 필요한 라이브러리만 로드되므로 초기 로딩 시간이 단축되고 페이지 성능이 향상될 수 있습니다.

2️⃣ 페이지 렌더링 성능 개선

동적으로 Quill을 로드하면 페이지의 초기 렌더링 시간이 단축될 수 있습니다. 
초기 로딩 시간을 줄이는 것은 사용자 경험을 향상시키고 페이지의 빠른 렌더링을 가능하게 합니다.

3️⃣ 리소스 관리

필요하지 않은 경우에는 Quill을 로드하지 않고 필요할 때만 로드함으로써 애플리케이션의 메모리 리소스를 절약할 수 있습니다. 
특히, Quill을 사용하는 페이지가 많지 않은 경우에는 불필요한 리소스 사용을 피할 수 있습니다.

4️⃣ 코드 스플리팅

동적으로 Quill을 로드하면 코드를 더 작은 청크(chunk)로 나눌 수 있으며, 
이는 코드 스플리팅을 통해 애플리케이션의 성능을 최적화할 수 있는 기회를 제공합니다.

<br />

Jayden 님이 만든 에디터 :

<p align="center">
<img width="45%"  src="https://github.com/mobi-projects/yeogi-client/assets/134191817/68a5e381-60d6-47e1-a1b5-8355c6d02a02">
<img width="45%" src="https://github.com/mobi-projects/yeogi-client/assets/134191817/934086cf-3a8c-44e5-a4da-48d8be4d08a8">
</ p>

quill 에디터를 커스텀한 모습 :

<p align="center">
<img width="1802" src="https://github.com/mobi-projects/yeogi-client/assets/134191817/c284aa30-a5ee-46ab-98ec-0b51e33b6d06">
</ p>


<br />

제공하는 기능들의 차이와 변경할 수 없는 디자인이 있어 Jayden 님의 에디터와 차이가 있습니다.

에디터의 툴바(tool-bar)와 텍스트를 입력 받는 부분(container) 사이의 간격을 떨어뜨릴 수 있지만 freeForm과 memoForm 에디터의 간격이 일정하지 않습니다. 

위에서 입력 받을 정보들 (다녀온 지역과 기간, 제목 등)을 사이에 두는 것이 아닌 다른 곳에 두는 것이 나을지 아니면 페이지마다 toolbar와 container의 간격을 다르게 주는 것이 나을지 Jayden 님 및 다른 프론트 분들의 의견 궁금합니다.

우선은 두 개가 붙어 있을 것이라는 가정 하에 임의의 간격(20px)으로 설정해두었습니다.

<br/>

### 👩🏻‍💻 의견 공유합니다 

react-quill 라이브러리에서 기본적으로 이미지는 base64로 인코딩되어서 img 태그의 src 속성에 삽입되기 때문에 사용자가 짧은 글을 작성했다 하더라도 이미지 때문에 내용이 어마어마하게 길어진다고 합니다. quill을 사용한 다른 개발자 분들은 그래서 이 이미지를 s3와 cloudfront를 이용해서 클라우드 서버 url을 통해 이미지를 불러오도록 변경한다고 하니 이 부분 고려해보면 좋을 것 같습니다.

<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```