### PR TITLE
YG-83 [HOTFIX]: success to fail modal

### DIFF
--- a/app/(afterLogin)/detailPost/[postId]/_components/comment/commentDeleteButton.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/_components/comment/commentDeleteButton.tsx
@@ -1,6 +1,6 @@
 import { deleteComment } from "@/apis/commentApi"
 import { deleteCommentProps } from "./type"
-import { useModalStore } from "@/libs/modalStore"
+import useModalStore from "@/libs/modalStore"
 
 const CommentDeleteButton = ({ commentId }: deleteCommentProps) => {
     const { setIsDelete } = useModalStore()

--- a/app/(afterLogin)/detailPost/[postId]/page.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/page.tsx
@@ -14,9 +14,10 @@ import CreateComment from "./_components/comment/createComment"
 import LikeToComment from "./_components/comment/likeToComment"
 import CommentBox from "./_components/comment/commentBox"
 import { Comment } from "./_components/comment/type"
-import { useModalStore } from "@/libs/modalStore"
+
 import DeleteModal from "@/components/commons/deleteModal"
 import { useCommentIdStore } from "@/libs/commentStore"
+import useModalStore from "@/libs/modalStore"
 
 const DetailPostPage = ({ params }: PostDetailProps) => {
     const { postId } = params

--- a/app/(beforeLogin)/_auth/signin/signinForm.tsx
+++ b/app/(beforeLogin)/_auth/signin/signinForm.tsx
@@ -9,7 +9,7 @@ import Button from "@/components/commons/button"
 import useSignin from "@/hook/useSignin"
 import { UserRequest } from "./type"
 import Overlay from "@/components/commons/overlay"
-import FailModal from "@/components/commons/failModal"
+import SuccessToFailModal from "@/components/commons/successToFailModal"
 
 const SigninForm = () => {
     const [isChecked, setIsChecked] = useState(false)
@@ -80,19 +80,21 @@ const SigninForm = () => {
                     {isOpen && (
                         <Overlay isOpen={isOpen} onClick={() => handleOverlay(false)} rounded="lg">
                             {formState === "success" && (
-                                <FailModal
-                                    title="로그인성공성공성공성공"
+                                <SuccessToFailModal
+                                    title="로그인"
                                     isOpen={isOpen}
-                                    setIsOpen={handleOverlay}
-                                    context="다양한 사람들의 세계 곳곳의 여행 추억을 여기에서 확인하세요."
+                                    onClick={() => handleOverlay(false)}
+                                    context="다양한 세계여행 추억을"
+                                    state="success"
                                 />
                             )}
                             {formState === "fail" && (
-                                <FailModal
+                                <SuccessToFailModal
                                     title="로그인"
                                     isOpen={isOpen}
-                                    setIsOpen={handleOverlay}
+                                    onClick={() => handleOverlay(false)}
                                     context="이메일과 비밀번호를 다시 한번 확인해주세요."
+                                    state="fail"
                                 />
                             )}
                         </Overlay>

--- a/components/commons/comment.tsx
+++ b/components/commons/comment.tsx
@@ -7,8 +7,8 @@ import { formatISODateString } from "@/utils/formatDate"
 import { useEffect, useState } from "react"
 import SuccessToFailModal from "./successToFailModal"
 import LikeButton from "./likeButton"
-import { useModalStore } from "@/libs/modalStore"
 import { useCommentIdStore } from "@/libs/commentStore"
+import useModalStore from "@/libs/modalStore"
 
 const Comment = ({ commentId, content, likes, date, author, initialLiked }: CommentProps) => {
     const [isError, setIsError] = useState(false)

--- a/components/commons/successToFailModal.tsx
+++ b/components/commons/successToFailModal.tsx
@@ -17,9 +17,9 @@ const SuccessToFailModal = ({ title, context, isOpen, onClick, state }: FailModa
                 <div className="w-[360px] h-[360px] flex flex-col items-center justify-center bg-SYSTEM-white rounded-2xl z-60">
                     <div className="w-full flex items-center justify-center">
                         {state === "success" ? (
-                            <Image src="/public/icons/smile.svg" alt="happy" width={64} height={64} />
+                            <Image src="/icons/smile.svg" alt="happy" width={64} height={64} />
                         ) : (
-                            <Image src="/public/icons/unhappy.svg" alt="unhappy" width={64} height={64} />
+                            <Image src="/icons/unhappy.svg" alt="unhappy" width={64} height={64} />
                         )}
                     </div>
                     <div className="pt-[30px] pb-5">
@@ -37,7 +37,7 @@ const SuccessToFailModal = ({ title, context, isOpen, onClick, state }: FailModa
                     </div>
                     <div className="flex flex-col items-center justify-center">
                         <p>{context}</p>
-                        <p>잠시 후 다시 시도 해주세요.</p>
+                        {state === "success" ? <p>여기에서 확인 하세요</p> : <p>잠시 후 다시 시도 해주세요.</p>}
                     </div>
                 </div>
             </Overlay>

--- a/libs/modalStore.ts
+++ b/libs/modalStore.ts
@@ -1,12 +1,12 @@
-import {create} from 'zustand';
-import { ModalStore } from './type';
+import { create } from "zustand"
+import { ModalStore } from "./type"
 
-const useModalStore = create<ModalStore>((set) => ({
+const useModalStore = create<ModalStore>(set => ({
     showLoginModal: false,
     openLoginModal: () => set({ showLoginModal: true }),
     closeModal: () => set({ showLoginModal: false }),
     isDelete: false,
     setIsDelete: (isDelete: boolean) => set({ isDelete }),
-}));
+}))
 
-export default useModalStore;
+export default useModalStore

--- a/libs/pinStore.ts
+++ b/libs/pinStore.ts
@@ -1,4 +1,4 @@
-import create from "zustand"
+import { create } from "zustand"
 import { MapStore } from "./type"
 
 export const useMapStore = create<MapStore>(set => ({

--- a/libs/store.ts
+++ b/libs/store.ts
@@ -1,4 +1,4 @@
-import create from "zustand"
+import { create } from "zustand"
 import { initialFormData } from "@/apis/type"
 import { FormState, SelectionState } from "./type"
 


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->
- [YG-83 🔥HOTFIX: useModalStore 임포트 문제 해결](https://github.com/mobi-projects/yeogi-client/commit/c3f9a880ae7eee4f9ed895eb69e395f435894fb7)
- [YG-83 🔥HOTFIX: successToFailModal 긴급 수정](https://github.com/mobi-projects/yeogi-client/commit/22ab5715733a794893140466b064ad65af0be82d)
- [YG-83 🔥HOTFIX: #open #close #comment zustand import 문제 해결](https://github.com/mobi-projects/yeogi-client/commit/88f75359b1d0efef5625af03669b693bc84d8315)

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->

- signin form 에서 사용중이던 failModal을 successToFailModal로 변경하였습니다

- 병합 과정에서 잘못된 useModalStore의 import 문제를 해결하였습니다

- successToFailModal의 내용을 일부 수정했습니다

- zustand의 create import 시 중괄호가 없는 문제를 해결했습니다

<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```