### PR TITLE
YG - 121 [refactor] : header userprofileimage

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -23,7 +23,7 @@ const AuthForm = () => {
 
     const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${K_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`
     const googleURL = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&scope=openid%20email%20profile&client_id=${G_REST_API_KEY}&redirect_uri=${REDIRECT_URI}`
-    const naverURL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${N_REST_API_KEY}&state=${naverState}&redirect_uri=${REDIRECT_URI}`
+    const naverURL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${N_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&state=${naverState}`
 
     const handleMoveSocialLogin = (url: string, provider: Provider) => {
         setProvider(provider)
@@ -39,7 +39,6 @@ const AuthForm = () => {
                 const data = await postAuthCode(savedProvider)
                 setCookieToken(data.accessToken)
                 setSessionToken(data.accessToken)
-                // router.push("/")
             }
         }
         fetchData()

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -22,7 +22,7 @@ const AuthForm = () => {
     const router = useRouter()
 
     const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${K_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`
-    const googleURL = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&scope=openid%20email&client_id=${G_REST_API_KEY}&redirect_uri=${REDIRECT_URI}`
+    const googleURL = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&scope=openid%20email%20profile&client_id=${G_REST_API_KEY}&redirect_uri=${REDIRECT_URI}`
     const naverURL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${N_REST_API_KEY}&state=${naverState}&redirect_uri=${REDIRECT_URI}`
 
     const handleMoveSocialLogin = (url: string, provider: Provider) => {
@@ -39,7 +39,7 @@ const AuthForm = () => {
                 const data = await postAuthCode(savedProvider)
                 setCookieToken(data.accessToken)
                 setSessionToken(data.accessToken)
-                router.push("/")
+                // router.push("/")
             }
         }
         fetchData()

--- a/components/layouts/_components/headerLogin.tsx
+++ b/components/layouts/_components/headerLogin.tsx
@@ -1,16 +1,24 @@
-"use Client"
+"use client"
 
 import Link from "next/link"
 import Image from "next/image"
 import ProtectedLink from "@/components/protectedLink"
-import { HeaderLoginProps } from "./type"
 import { useEffect, useState } from "react"
+import { useLoggedIn } from "@/libs/loginStore"
 
-const HeaderLogin = ({ isLoggedIn, userInfo }: HeaderLoginProps) => {
-    const [profileImage, setProfileImage] = useState<string>("")
+const HeaderLogin = () => {
+    const [profileImage, setProfileImage] = useState<string>("/images/sampleProfile.svg")
+    const [isImageLoading, setIsImageLoading] = useState(true)
+    const { isLoggedIn, userInfo } = useLoggedIn()
 
-    console.log("isLoggedIn:", isLoggedIn)
-    console.log("userInfo:", userInfo)
+    useEffect(() => {
+        if (userInfo) {
+            setIsImageLoading(true)
+            const image = getUserProfileImage()
+            setProfileImage(image)
+        }
+    }, [userInfo])
+
     const getUserProfileImage = (): string => {
         if (userInfo?.profile) {
             return userInfo.profile
@@ -20,33 +28,29 @@ const HeaderLogin = ({ isLoggedIn, userInfo }: HeaderLoginProps) => {
         }
         return "/images/sampleProfile.svg"
     }
-    useEffect(() => {
-        if (userInfo) {
-            setProfileImage(getUserProfileImage())
-        }
-    }, [userInfo])
+
+    const handleImageLoad = () => {
+        setIsImageLoading(false)
+    }
+
     return (
         <>
             {isLoggedIn ? (
-                <Link href={`/user/${userInfo?.id}`}>
-                    {userInfo?.profile || userInfo?.profile_image ? (
+                <Link href={`/user/${userInfo?.id}`} className="w-12 h-12 relative">
+                    {isImageLoading && (
+                        <div className="absolute inset-0 flex items-center justify-center bg-gray-200 rounded-full">
+                            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-gray-900"></div>
+                        </div>
+                    )}
+                    {profileImage && (
                         <Image
-                            src={getUserProfileImage()}
+                            src={profileImage}
                             alt="profile"
                             width={48}
                             height={48}
-                            className="rounded-full"
+                            className={`rounded-full ${isImageLoading ? "invisible" : "visible"}`}
+                            onLoadingComplete={handleImageLoad}
                         />
-                    ) : (
-                        <div>
-                            <Image
-                                src={"/images/sampleProfile.svg"}
-                                alt="Profile"
-                                width={48}
-                                height={48}
-                                className="rounded-full"
-                            />
-                        </div>
                     )}
                 </Link>
             ) : (
@@ -57,4 +61,5 @@ const HeaderLogin = ({ isLoggedIn, userInfo }: HeaderLoginProps) => {
         </>
     )
 }
+
 export default HeaderLogin

--- a/components/layouts/_components/headerLogin.tsx
+++ b/components/layouts/_components/headerLogin.tsx
@@ -1,15 +1,42 @@
+"use Client"
+
 import Link from "next/link"
 import Image from "next/image"
 import ProtectedLink from "@/components/protectedLink"
 import { HeaderLoginProps } from "./type"
+import { useEffect, useState } from "react"
 
 const HeaderLogin = ({ isLoggedIn, userInfo }: HeaderLoginProps) => {
+    const [profileImage, setProfileImage] = useState<string>("")
+
+    console.log("isLoggedIn:", isLoggedIn)
+    console.log("userInfo:", userInfo)
+    const getUserProfileImage = (): string => {
+        if (userInfo?.profile) {
+            return userInfo.profile
+        }
+        if (userInfo?.profile_image) {
+            return userInfo.profile_image
+        }
+        return "/images/sampleProfile.svg"
+    }
+    useEffect(() => {
+        if (userInfo) {
+            setProfileImage(getUserProfileImage())
+        }
+    }, [userInfo])
     return (
         <>
             {isLoggedIn ? (
                 <Link href={`/user/${userInfo?.id}`}>
-                    {userInfo?.profile ? (
-                        <Image src={userInfo.profile} alt="profile" width={48} height={48} className="rounded-full" />
+                    {userInfo?.profile || userInfo?.profile_image ? (
+                        <Image
+                            src={getUserProfileImage()}
+                            alt="profile"
+                            width={48}
+                            height={48}
+                            className="rounded-full"
+                        />
                     ) : (
                         <div>
                             <Image

--- a/components/layouts/header.tsx
+++ b/components/layouts/header.tsx
@@ -5,18 +5,17 @@ import Image from "next/image"
 import ProtectedLink from "../protectedLink"
 import { getCookieToken } from "@/apis/auth/storageUtils"
 import { getUserInfo } from "@/apis/userApi"
-import { UserInfoProps } from "./type"
 import HeaderSearchBar from "./_components/headerSearch"
 import HeaderLogin from "./_components/headerLogin"
 import HeaderNavigate from "./_components/headerNavigate"
 import { useRouter } from "next/navigation"
+import { useLoggedIn } from "@/libs/loginStore"
 
 const Header = () => {
     const [isShowHeader, setIsShowHeader] = useState<boolean>(true)
     const [lastScrollY, setLastScrollY] = useState<number>(0)
     const [isSearchBarClicked, setIsSearchBarClicked] = useState<boolean>(false)
-    const [isLoggedIn, setIsLoggedIn] = useState<boolean>(false)
-    const [userInfo, setUserInfo] = useState<UserInfoProps | undefined>()
+    const { setIsLoggedIn, setUserInfo } = useLoggedIn()
 
     const router = useRouter()
     const handleScroll = () => {
@@ -42,6 +41,7 @@ const Header = () => {
 
     useEffect(() => {
         const fetchUserData = async () => {
+            await new Promise(resolve => setTimeout(resolve, 1000))
             const token = getCookieToken()
             if (token) {
                 setIsLoggedIn(true)
@@ -50,7 +50,7 @@ const Header = () => {
             }
         }
         fetchUserData()
-    }, [])
+    }, [setIsLoggedIn, setUserInfo])
 
     return (
         <header
@@ -74,7 +74,7 @@ const Header = () => {
                             isSearchBarClicked={isSearchBarClicked}
                             setIsSearchBarClicked={setIsSearchBarClicked}
                         />
-                        <HeaderLogin isLoggedIn={isLoggedIn} userInfo={userInfo} />
+                        <HeaderLogin />
                         <ProtectedLink href="/createPost">
                             <button className="bg-SYSTEM-black text-SYSTEM-white md:w-[120px] md:h-[46px] w-[46px] h-[46px] rounded-full flex items-center justify-center md:px-5 md:py-[13.5px]  ">
                                 <Image

--- a/components/layouts/type.ts
+++ b/components/layouts/type.ts
@@ -4,7 +4,8 @@ export type UserInfoProps = {
     nickname: string
     ageRange: string
     gender: "M" | "W"
-    profile: string
+    profile?: string //google profileImage
+    profile_image?: string //naver & kakao profileImage
     motto: string
     banner: string
 }

--- a/libs/loginStore.ts
+++ b/libs/loginStore.ts
@@ -1,0 +1,10 @@
+import { create } from "zustand";
+import { LoginState } from "./type";
+import { UserInfoProps } from "@/components/layouts/type";
+
+export const useLoggedIn = create<LoginState>(set => ({
+    isLoggedIn: false,
+    setIsLoggedIn: (loggedIn) => set({isLoggedIn: loggedIn}),
+    userInfo: undefined,
+    setUserInfo: (userInfo?: UserInfoProps) => set({userInfo})
+}))

--- a/libs/type.ts
+++ b/libs/type.ts
@@ -1,4 +1,5 @@
 import { ThemeProps } from "@/app/_components/type"
+import { UserInfoProps } from "@/components/layouts/type"
 import { Continent } from "@/constants/continents"
 import { CreatePost, ShortPosts } from "@/utils/type"
 import { Dayjs } from "dayjs"
@@ -83,4 +84,11 @@ export type ThemeState = {
     setShowResult: (value: boolean) => void
     topTags: ThemeProps[]
     setTopTags: (tags: ThemeProps[]) => void
+}
+
+export type LoginState = {
+    isLoggedIn: boolean
+    setIsLoggedIn: (isLoggedIn: boolean) => void
+    userInfo: UserInfoProps | undefined
+    setUserInfo: (userInfo: UserInfoProps) => void
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     images: {
-        domains: ["source.unsplash.com", "lh3.googleusercontent.com"],
+        domains: ["source.unsplash.com", "lh3.googleusercontent.com","ssl.pstatic.net","k.kakaocdn.net"],
     },
     async rewrites() {
         return [


### PR DESCRIPTION
## 개요

[YG-121 💡 refactor : 새로고침시, 프로필 변경되는점 수정](https://github.com/mobi-projects/yeogi-client/commit/580cbfdd9e1a7feb334b652498e2cb4b573d7049)

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
- Naver 로그인시, 사용자에게 보여지는 address 를 수정했습니다.
- Google 로그인시, 사용자에게 보여지는 address 를 수정했습니다.
```tsx
const kakaoURL = `https://kauth.kakao.com/oauth/authorize?client_id=${K_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`
    const googleURL = `https://accounts.google.com/o/oauth2/v2/auth?response_type=code&scope=openid%20email%20profile&client_id=${G_REST_API_KEY}&redirect_uri=${REDIRECT_URI}`
    const naverURL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${N_REST_API_KEY}&redirect_uri=${REDIRECT_URI}&state=${naverState}`
```
- Naver, Kakao 도 헤더 프로필 사진에 나올수 있도록 수정했습니다.
네이버와 카카오에서 지원하는 scope가 달라 프로필 사진을 못불러오는 이슈를 각각 type을 따로 설정하였습니다.
```tsx
export type UserInfoProps = {
    id: number
    email: string
    nickname: string
    ageRange: string
    gender: "M" | "W"
    profile?: string //google profileImage
    profile_image?: string //naver & kakao profileImage
    motto: string
    banner: string
}
```
```tsx
//headerLogin component
    const getUserProfileImage = (): string => {
        if (userInfo?.profile) {
            return userInfo.profile
        }
        if (userInfo?.profile_image) {
            return userInfo.profile_image
        }
        return "/images/sampleProfile.svg"
    }
```
(Kakao의 경우 프로필 사진 크기에 따라 48*48 크기가 안될수 있습니다... 저도 알고싶지않았습니다)
<카카오로그인시>
![스크린샷 2024-07-08 오후 6 25 16](https://github.com/mobi-projects/yeogi-client/assets/142880051/ffd5563f-bb5a-4f7b-a256-72bd4dc6708d)
<네이버 로그인시>
![스크린샷 2024-07-08 오후 6 25 36](https://github.com/mobi-projects/yeogi-client/assets/142880051/764b6c7f-ef31-443e-bdc3-2eb81e54172a)


- 기존 로그인방식에서 로그인시, 새로고침해야 헤더에 프로필 사진이 나왔는데 이부분 전역상태로 관리 + setTime설정하여 새로고침 없이도 헤더에 프로필 이미지가 나오게끔 수정했습니다.

전역 상태로 관리
```tsx
export const useLoggedIn = create<LoginState>(set => ({
    isLoggedIn: false,
    setIsLoggedIn: (loggedIn) => set({isLoggedIn: loggedIn}),
    userInfo: undefined,
    setUserInfo: (userInfo?: UserInfoProps) => set({userInfo})
}))
```



### 최종결과물


https://github.com/mobi-projects/yeogi-client/assets/142880051/ef0f5e58-d043-4ca2-8d8c-4074c8aebed5



## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```