### PR TITLE
YG-129 [feat] : edit post's like function

### DIFF
--- a/apis/commentApi.ts
+++ b/apis/commentApi.ts
@@ -1,6 +1,6 @@
 import { postCommentResponse } from "@/hook/type"
 
-import { postCommentProps, getCommentProps, commentIdProps, deleteCommentProps, putCommentProps } from "./type"
+import { postCommentProps, getCommentProps, commentIdProps, deleteCommentProps, putCommentProps, postIdProps } from "./type"
 import { fetchFormAPI, fetchFormAPINotToken } from "./api.utils"
 
 const API_URL = "/comments"

--- a/apis/postApi.ts
+++ b/apis/postApi.ts
@@ -1,5 +1,5 @@
 
-import { getPostProps } from "./type"
+import { getPostProps, postIdProps } from "./type"
 import { ThemeProps } from "@/app/_components/type"
 import { CreatePost, Post, UpdatePost } from "@/types/post"
 import { fetchFormAPI, fetchFormAPINotToken } from "./api.utils"
@@ -154,11 +154,22 @@ export const postViews = async (postId: number) => {
 
 /**
  * @function
- * @param {commentIdProps} props
+ * @param {postIdProps} props
  * @param {number} props.commentId - 좋아요를 추가할 게시글 ID
  * @description 게시글에 좋아요 추가하는 API
  */
-export const postLike = async (postId: number) => {
-    await fetchFormAPINotToken(POST_API_URL, `posts/${postId}likes`, { method: "POST" })
+export const postPostLike = async ({postId}: postIdProps) => {
+    await fetchFormAPI(POST_API_URL, `posts/${postId}/likes`, { method: "POST" })
     return postId
+}
+
+/**
+ * @function
+ * @param {postIdProps} props
+ * @param {number} props.commentId - 좋아요를 제거할 댓글 ID
+ * @description 게시글에 추가된 좋아요 삭제 API
+ */
+export const deletePostLike = async ({ postId }: postIdProps) => {
+    await fetchFormAPI(POST_API_URL, `post/${postId}/likes`, { method: "DELETE" })
+    return { postId }
 }

--- a/apis/postApi.ts
+++ b/apis/postApi.ts
@@ -170,6 +170,6 @@ export const postPostLike = async ({postId}: postIdProps) => {
  * @description 게시글에 추가된 좋아요 삭제 API
  */
 export const deletePostLike = async ({ postId }: postIdProps) => {
-    await fetchFormAPI(POST_API_URL, `post/${postId}/likes`, { method: "DELETE" })
+    await fetchFormAPI(POST_API_URL, `posts/${postId}/likes`, { method: "DELETE" })
     return { postId }
 }

--- a/apis/type.ts
+++ b/apis/type.ts
@@ -43,6 +43,10 @@ export type commentIdProps = {
     commentId: number
 }
 
+export type postIdProps={
+    postId:number
+}
+
 export type fetchCommentProps = {
     postIds: number[]
 }

--- a/app/(afterLogin)/createPost/_components/calendar/calendar.tsx
+++ b/app/(afterLogin)/createPost/_components/calendar/calendar.tsx
@@ -5,7 +5,7 @@ import dayjs, { Dayjs } from "dayjs"
 import advancedFormat from "dayjs/plugin/advancedFormat"
 import isBetween from "dayjs/plugin/isBetween"
 import { generateCalendarOptions, generateDays, renderDay, renderDayOfWeek } from "./calendarUtils"
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 
 dayjs.extend(advancedFormat)
 dayjs.extend(isBetween)

--- a/app/(afterLogin)/createPost/_components/form/formSelector.tsx
+++ b/app/(afterLogin)/createPost/_components/form/formSelector.tsx
@@ -1,4 +1,4 @@
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 import { FormSelectorProps } from "./type"
 import Image from "next/image"
 import { Theme } from "@/types/theme"

--- a/app/(afterLogin)/createPost/_components/form/selectedTheme.tsx
+++ b/app/(afterLogin)/createPost/_components/form/selectedTheme.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Button from "@/components/commons/button"
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 import { useEffect, useState } from "react"
 import { ThemeProps } from "@/app/_components/type"
 import { Theme } from "@/types/theme"

--- a/app/(afterLogin)/createPost/_components/overlay/uploadOverlay.tsx
+++ b/app/(afterLogin)/createPost/_components/overlay/uploadOverlay.tsx
@@ -7,7 +7,7 @@ import { useState } from "react"
 import { UploadOverlayProps } from "./type"
 import ThumbnailUploader from "./thumbnailUploader"
 import PreviewPostCard from "./previewPostcard"
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 
 const UploadOverlay = ({ isOverlayOpen, setIsOverlayOpen, handleOverlaySubmit, memos }: UploadOverlayProps) => {
     const [selectedImage, setSelectedImage] = useState<string | null>(null)

--- a/app/(afterLogin)/createPost/_components/region/countriesSearch.tsx
+++ b/app/(afterLogin)/createPost/_components/region/countriesSearch.tsx
@@ -7,7 +7,7 @@ import Overlay from "@/components/commons/overlay"
 import Image from "next/image"
 import backIcon from "@/public/icons/white_arrow-left.svg"
 import useCountrySearch from "@/hook/useCountrySearch"
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 import { CountrySearchProps } from "./type"
 
 const CountriesSearch = ({ isOpen, onSelect, selectedContinent, setNextStep }: CountrySearchProps) => {

--- a/app/(afterLogin)/createPost/_components/region/selectContinent.tsx
+++ b/app/(afterLogin)/createPost/_components/region/selectContinent.tsx
@@ -5,7 +5,7 @@ import { Continent } from "@/constants/continents"
 import { useState } from "react"
 import Button from "@/components/commons/button"
 import CountriesSearch from "./countriesSearch"
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 import { selectContinentProps } from "./type"
 
 const SelectedContinent = ({ isOpen, onClick, nextStep, setNextStep }: selectContinentProps) => {

--- a/app/(afterLogin)/createPost/_components/region/selectedAddress.tsx
+++ b/app/(afterLogin)/createPost/_components/region/selectedAddress.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react"
 import Overlay from "../form/formOverlay"
 import { SelectedAddressProps, address } from "./type"
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 import AddressAutoComplete from "./addressAutoComplete"
 
 const SelectedAddress = ({ isOpen, onClick, setIsOpen, onSelect }: SelectedAddressProps) => {

--- a/app/(afterLogin)/detailPost/[postId]/_components/comment/_components/likeButton.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/_components/comment/_components/likeButton.tsx
@@ -1,34 +1,12 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { postCommentLike, deleteCommentLike } from "@/apis/commentApi"
 import Image from "next/image"
 import LikeIcon from "@/public/icons/like.svg"
 import { LikeButtonProps } from "./type"
+import useLikeHandler from "@/hook/useCommentLikeHandler"
 
 const CommentLikeButton = ({ commentId, initialLikes, initialLiked, setIsError, size, textSize }: LikeButtonProps) => {
-    const [likeCount, setLikeCount] = useState(initialLikes)
-    const [liked, setLiked] = useState(initialLiked)
-
-    useEffect(() => {
-        setLikeCount(initialLikes)
-        setLiked(initialLiked)
-    }, [initialLikes, initialLiked])
-
-    const handleLikeClick = async () => {
-        try {
-            if (liked) {
-                await deleteCommentLike({ commentId })
-                setLikeCount(likeCount - 1)
-            } else {
-                await postCommentLike({ commentId })
-                setLikeCount(likeCount + 1)
-            }
-            setLiked(!liked)
-        } catch (error) {
-            setIsError(true)
-        }
-    }
+    const { likes, handleLikeClick } = useLikeHandler(commentId, initialLikes, initialLiked, setIsError)
 
     return (
         <>
@@ -41,7 +19,7 @@ const CommentLikeButton = ({ commentId, initialLikes, initialLiked, setIsError, 
                     onClick={handleLikeClick}
                     className="hover:cursor-pointer"
                 />
-                <span className={`pl-2 text-GREY-80 ${textSize}`}>{likeCount}개</span>
+                <span className={`pl-2 text-GREY-80 ${textSize}`}>{likes}개</span>
             </div>
         </>
     )

--- a/app/(afterLogin)/detailPost/[postId]/_components/comment/_components/likeToComment.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/_components/comment/_components/likeToComment.tsx
@@ -3,7 +3,7 @@ import { LikeToComments } from "./type"
 
 const LikeToComment = ({ likes, comments }: LikeToComments) => {
     return (
-        <div className="w-full flex items-center justify-center bg-red-300">
+        <div className="w-full flex items-center justify-center ">
             <div className="w-[1000px] flex flex-row pt-[50px]">
                 <div className="w-[80px] flex flex-row items-center">
                     <Image src={"/icons/like.svg"} alt="Like" width={24} height={24} />

--- a/app/(afterLogin)/detailPost/[postId]/_components/comment/_components/likeToComment.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/_components/comment/_components/likeToComment.tsx
@@ -3,7 +3,7 @@ import { LikeToComments } from "./type"
 
 const LikeToComment = ({ likes, comments }: LikeToComments) => {
     return (
-        <div className="w-full flex items-center justify-center">
+        <div className="w-full flex items-center justify-center bg-red-300">
             <div className="w-[1000px] flex flex-row pt-[50px]">
                 <div className="w-[80px] flex flex-row items-center">
                     <Image src={"/icons/like.svg"} alt="Like" width={24} height={24} />

--- a/app/(afterLogin)/detailPost/[postId]/_components/floating/floatingBar.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/_components/floating/floatingBar.tsx
@@ -10,7 +10,7 @@ import { useLikeStore } from "@/libs/likeStore"
 const FloatingBar = ({ icons, isMine, postId, post }: FloatingBarProps) => {
     const [iconState, setIconState] = useState<FloatingIcon[]>(icons)
     const numericPostId = Number(postId)
-    const { isActiveState, handleClick, handleModalClose, isUpdateInProgress } = useFloatingBarHandler({
+    const { isActiveState, handleClick, handleModalClose, isUpdateInProgress, isLoading } = useFloatingBarHandler({
         postId: numericPostId,
         post,
         setIconState,
@@ -24,11 +24,15 @@ const FloatingBar = ({ icons, isMine, postId, post }: FloatingBarProps) => {
         }
     }, [])
 
+    if (isLoading) {
+        return <div>Loading...</div>
+    }
+
     return (
         <div className={`fixed ${isMine ? "top-[53%]" : "top-[31%]"}`}>
             <div className="absolute z-50" style={{ left: `561px` }}>
                 <div
-                    className={` shadow-lg rounded-[92px] p-2 flex flex-col items-center gap-2 ${isMine ? "bg-GREY-30" : "bg-BRAND-10"}`}
+                    className={`shadow-lg rounded-[92px] p-2 flex flex-col items-center gap-2 ${isMine ? "bg-GREY-30" : "bg-BRAND-10"}`}
                 >
                     {iconState.map((icon, idx) => (
                         <FloatingButton key={idx} icon={icon} onClick={() => handleClick(icon.name)} />

--- a/app/(afterLogin)/detailPost/[postId]/_components/floating/floatingBar.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/_components/floating/floatingBar.tsx
@@ -3,16 +3,26 @@
 import useFloatingBarHandler from "@/hook/useFloatingBarHandler"
 import FloatingButton from "./floatingButton"
 import { FloatingBarProps, FloatingIcon } from "./type"
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import StillWorkingOverlay from "@/components/commons/stillWorkingOverlay"
+import { useLikeStore } from "@/libs/likeStore"
 
 const FloatingBar = ({ icons, isMine, postId, post }: FloatingBarProps) => {
     const [iconState, setIconState] = useState<FloatingIcon[]>(icons)
+    const numericPostId = Number(postId)
     const { isActiveState, handleClick, handleModalClose, isUpdateInProgress } = useFloatingBarHandler({
-        postId,
+        postId: numericPostId,
         post,
         setIconState,
     })
+    const { likes, setLikes } = useLikeStore()
+
+    useEffect(() => {
+        // 초기 좋아요 수 설정
+        if (postId && post && !likes[numericPostId]) {
+            setLikes(numericPostId, post.likeCount)
+        }
+    }, [])
 
     return (
         <div className={`fixed ${isMine ? "top-[53%]" : "top-[31%]"}`}>

--- a/app/(afterLogin)/detailPost/[postId]/_components/floating/type.ts
+++ b/app/(afterLogin)/detailPost/[postId]/_components/floating/type.ts
@@ -14,6 +14,6 @@ export type FloatingButtonType = {
 export type FloatingBarProps = {
     icons: { name: string; icon: string; isActive: boolean }[]
     isMine?: boolean
-    postId?: string
-    post?: Post
+    postId: number 
+    post?: Post | undefined
 }

--- a/app/(afterLogin)/detailPost/[postId]/_components/floating/type.ts
+++ b/app/(afterLogin)/detailPost/[postId]/_components/floating/type.ts
@@ -15,5 +15,5 @@ export type FloatingBarProps = {
     icons: { name: string; icon: string; isActive: boolean }[]
     isMine?: boolean
     postId: number 
-    post?: Post | undefined
+    post: Post
 }

--- a/app/(afterLogin)/detailPost/[postId]/page.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/page.tsx
@@ -71,7 +71,7 @@ const DetailPostPage = ({ params }: PostDetailProps) => {
             />
             <div className="flex items-center justify-center flex-col">
                 <div className="relative w-[1300px] flex flex-col items-center justify-center py-10">
-                    <FloatingBar icons={defaultIcons} postId={Number(postId)} />
+                    <FloatingBar icons={defaultIcons} postId={Number(postId)} post={post} />
                     <FloatingBar icons={handlePostIcons} isMine={true} postId={Number(postId)} post={post} />
                     <PostDetail post={post} />
                 </div>

--- a/app/(afterLogin)/detailPost/[postId]/page.tsx
+++ b/app/(afterLogin)/detailPost/[postId]/page.tsx
@@ -11,7 +11,7 @@ import CreateComment from "./_components/comment/createComment"
 import CommentBox from "./_components/comment/commentBox"
 import { Comment } from "./_components/comment/type"
 import { defaultIcons, handlePostIcons } from "@/constants/floatingBarIcons"
-import { usePostDataStore } from "@/libs/store"
+import { usePostDataStore } from "@/libs/postStore"
 import { useEffect } from "react"
 import DeleteModal from "@/components/commons/deleteModal"
 import { useCommentIdStore } from "@/libs/commentStore"
@@ -71,8 +71,8 @@ const DetailPostPage = ({ params }: PostDetailProps) => {
             />
             <div className="flex items-center justify-center flex-col">
                 <div className="relative w-[1300px] flex flex-col items-center justify-center py-10">
-                    <FloatingBar icons={defaultIcons} />
-                    <FloatingBar icons={handlePostIcons} isMine={true} postId={postId} post={post} />
+                    <FloatingBar icons={defaultIcons} postId={Number(postId)} />
+                    <FloatingBar icons={handlePostIcons} isMine={true} postId={Number(postId)} post={post} />
                     <PostDetail post={post} />
                 </div>
                 <LikeToComment likes={post.likeCount} comments={comments.length} />

--- a/app/(afterLogin)/updatePost/[postId]/page.tsx
+++ b/app/(afterLogin)/updatePost/[postId]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCreatePostStore, usePostDataStore } from "@/libs/store"
+import { useCreatePostStore, usePostDataStore } from "@/libs/postStore"
 import { useCommonUpdatePost, useInitializeFormData } from "@/hook/updatePostFunctions"
 import CommonPost from "../../createPost/_components/commonPost"
 import { ThemeProps } from "@/app/_components/type"

--- a/hook/type.ts
+++ b/hook/type.ts
@@ -31,7 +31,7 @@ export type SigninResult = UseMutationResult<UserResponse, Error, UserRequest> &
 export type useHandleClickProps = {
     postId: number
     liked? : boolean
-    post?: Post
+    post: Post
     setIconState: Dispatch<SetStateAction<FloatingIcon[]>>
 }
 

--- a/hook/type.ts
+++ b/hook/type.ts
@@ -29,7 +29,8 @@ export type SigninResult = UseMutationResult<UserResponse, Error, UserRequest> &
     handleOverlay: (isOpen: boolean, state?: "success" | "fail" | null) => void
 }
 export type useHandleClickProps = {
-    postId?: string
+    postId: number
+    liked? : boolean
     post?: Post
     setIconState: Dispatch<SetStateAction<FloatingIcon[]>>
 }

--- a/hook/updatePostFunctions.ts
+++ b/hook/updatePostFunctions.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 import { memos, UpdatePost } from "@/types/post"
 import { processContentImages } from "@/utils/form.utils"
 import { UseMutationResult } from "@tanstack/react-query"
@@ -132,7 +132,7 @@ export const useCommonUpdatePost = () => {
      * @param {Date | null} endDate 여행 종료 날짜
      */
     const handleUpdatePost = async (
-        postId: string,
+        postId: number,
         formData: UpdatePost,
         quillEditors: Array<{ content: string }>,
         setIsSubmitted: (isSubmitted: boolean) => void,
@@ -170,7 +170,7 @@ export const useCommonUpdatePost = () => {
 
         try {
             await updatePostMutation.mutateAsync({
-                postId: parseInt(postId),
+                postId: postId,
                 editedFields: editedPost,
             })
             setIsSubmitted(true)

--- a/hook/useCommentLikeHandler.ts
+++ b/hook/useCommentLikeHandler.ts
@@ -5,7 +5,7 @@ import { useLikeStore } from "@/libs/likeStore";
 const useLikeHandler = (commentId: number, initialLikes: number, initialLiked: boolean, setIsError: (error: boolean) => void) => {
     const { likes, setLikes } = useLikeStore();
     const [liked, setLiked] = useState(initialLiked);
-
+   
     useEffect(() => {
         if(likes[commentId] === undefined){
             setLikes(commentId, initialLikes); // 초기 좋아요 수 설정

--- a/hook/useCommonPost.ts
+++ b/hook/useCommonPost.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { FormEvent, useState } from "react"
-import { useCreatePostStore } from "@/libs/store"
+import { useCreatePostStore } from "@/libs/postStore"
 import { postPost } from "@/apis/postApi"
 import { CreatePost, memos } from "@/types/post"
 import { useMapStore } from "@/libs/pinStore"

--- a/hook/useFloatingBarHandler.ts
+++ b/hook/useFloatingBarHandler.ts
@@ -3,10 +3,11 @@
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useDeletePost } from "@/hook/usePostMutation"
-import { usePostDataStore } from "@/libs/store"
+import { usePostDataStore } from "@/libs/postStore"
 import { useHandleClickProps } from "./type"
 import { FloatingIcon } from "@/app/(afterLogin)/detailPost/[postId]/_components/floating/type"
 import useHandleScroll from "@/hook/useHandleScroll"
+import usePostLikeHandler from "./usePostLikeHandler"
 
 const useFloatingBarHandler = ({ postId, post, setIconState }: useHandleClickProps) => {
     const [isActiveState, setIsActiveState] = useState<{ [key: string]: boolean }>({
@@ -22,7 +23,16 @@ const useFloatingBarHandler = ({ postId, post, setIconState }: useHandleClickPro
     const deletePostMutation = useDeletePost()
     const { setPostId, setPostDetail } = usePostDataStore()
     const [isUpdateInProgress, setIsUpdateInProgress] = useState(false)
+    const setIsError = (error: boolean) => {
+        console.log(error, "error")
+     };
 
+     if(postId === undefined) {
+        throw new Error
+     }
+    const { handleLikeClick } = usePostLikeHandler(postId , post?.likeCount || 0, post?.liked|| false, setIsError);
+
+    console.log(postId,"handler")
     useEffect(() => {
         if (scrollY <= 20) {
             setIsActiveState(prev => ({ ...prev, arrow: false }))
@@ -97,8 +107,9 @@ const useFloatingBarHandler = ({ postId, post, setIconState }: useHandleClickPro
                 handleArrowClick()
                 break
             case "like":
-                setIsActiveState(prev => ({ ...prev, like: !prev.like }))
-                break
+                handleLikeClick()
+                setIsActiveState(prev => ({ ...prev, like: !prev.like }));
+                    break
             case "share":
                 handleShareClick()
                 break

--- a/hook/useFloatingBarHandler.ts
+++ b/hook/useFloatingBarHandler.ts
@@ -12,7 +12,7 @@ import usePostLikeHandler from "./usePostLikeHandler"
 const useFloatingBarHandler = ({ postId, post, setIconState }: useHandleClickProps) => {
     const [isActiveState, setIsActiveState] = useState<{ [key: string]: boolean }>({
         arrow: false,
-        like: false,
+        like: post?.liked || false,
         share: false,
         delete: false,
         update: false,
@@ -30,9 +30,14 @@ const useFloatingBarHandler = ({ postId, post, setIconState }: useHandleClickPro
      if(postId === undefined) {
         throw new Error
      }
-    const { handleLikeClick } = usePostLikeHandler(postId , post?.likeCount || 0, post?.liked|| false, setIsError);
+    const { handleLikeClick,liked } = usePostLikeHandler(postId , post?.likeCount || 0, post?.liked || false, setIsError);
+    useEffect(() => {
+        // liked 값에 따라 isActiveState 업데이트
+        setIsActiveState(prev => ({ ...prev, like: liked }));
+        console.log(isActiveState,"isActivestate")
+    }, [liked]);
 
-    console.log(postId,"handler")
+    console.log(liked, "liked1")
     useEffect(() => {
         if (scrollY <= 20) {
             setIsActiveState(prev => ({ ...prev, arrow: false }))

--- a/hook/useLikeHandler.ts
+++ b/hook/useLikeHandler.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+import { postCommentLike, deleteCommentLike } from "@/apis/commentApi";
+import { useLikeStore } from "@/libs/likeStore";
+
+const useLikeHandler = (commentId: number, initialLikes: number, initialLiked: boolean, setIsError: (error: boolean) => void) => {
+    const { likes, setLikes } = useLikeStore();
+    const [liked, setLiked] = useState(initialLiked);
+
+    useEffect(() => {
+        if(likes[commentId] === undefined){
+            setLikes(commentId, initialLikes); // 초기 좋아요 수 설정
+        }
+        setLiked(initialLiked);
+    }, [commentId, initialLikes, initialLiked, setLikes]);
+
+    const handleLikeClick = async () => {
+        try {
+            if (liked) {
+                await deleteCommentLike({ commentId });
+                setLikes(commentId, (likes[commentId] || initialLikes) - 1); // 좋아요 수 감소
+            } else {
+                await postCommentLike({ commentId });
+                setLikes(commentId, (likes[commentId] || initialLikes) + 1); // 좋아요 수 증가
+            }
+            setLiked(!liked);
+        } catch (error) {
+            setIsError(true);
+        }
+    };
+
+    return {
+        likes: likes[commentId] || initialLikes,
+        liked,
+        handleLikeClick,
+    };
+};
+
+export default useLikeHandler;

--- a/hook/usePostLikeHandler.ts
+++ b/hook/usePostLikeHandler.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from "react";
+import { useLikeStore } from "@/libs/likeStore";
+import { deletePostLike, postPostLike } from "@/apis/postApi";
+
+const usePostLikeHandler = (postId: number , initialLikes: number, initialLiked: boolean, setIsError: (error: boolean) => void) => {
+    const { likes, setLikes } = useLikeStore();
+    const [liked, setLiked] = useState(initialLiked);
+   
+    useEffect(() => {
+        if(likes[postId] === undefined){
+            setLikes(postId, initialLikes); // 초기 좋아요 수 설정
+        }
+        setLiked(initialLiked);
+    }, [postId, initialLikes, initialLiked, setLikes]);
+
+    const handleLikeClick = async () => {
+        try {
+            if (liked) {
+                await deletePostLike({ postId });
+                setLikes(postId, (likes[postId] || initialLikes) - 1); // 좋아요 수 감소
+            } else {
+                await postPostLike({ postId });
+                setLikes(postId, (likes[postId] || initialLikes) + 1); // 좋아요 수 증가
+            }
+            setLiked(!liked);
+        } catch (error) {
+            setIsError(true);
+        }
+    };
+
+    return {
+        likes: likes[postId] || initialLikes,
+        liked,
+        handleLikeClick,
+    };
+};
+
+export default usePostLikeHandler;

--- a/hook/usePostLikeHandler.ts
+++ b/hook/usePostLikeHandler.ts
@@ -5,10 +5,6 @@ import { deletePostLike, postPostLike } from "@/apis/postApi";
 import { useLoggedIn } from "@/libs/loginStore";
 import { Post } from "@/types/post";
 
-export type LikeUserId = {
-    id: number
-}
-
 const usePostLikeHandler = (postId: number, initialLiked: boolean, post: Post) => {
     const { userInfo, isLoading } = useLoggedIn();
     const [liked, setLiked] = useState<boolean>(initialLiked);

--- a/hook/useUpdatePost.ts
+++ b/hook/useUpdatePost.ts
@@ -1,7 +1,7 @@
 "use client"
 
 import { FormEvent, useState } from "react"
-import { useCreatePostStore, useUpdatePostDataStore } from "@/libs/store"
+import { useCreatePostStore, useUpdatePostDataStore } from "@/libs/postStore"
 import { postPost } from "@/apis/postApi"
 import { memos, UpdatePost } from "@/types/post"
 import { useUpdateFreePost } from "./usePostMutation"

--- a/libs/likeStore.ts
+++ b/libs/likeStore.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand"
+
+export type LikesState = {
+likes: {[key:number]: number}
+setLikes:(postId:number, likes:number)=>void
+}
+
+export const useLikeStore = create<LikesState>((set)=>({
+    likes:{},
+    setLikes:(postId , likes)=> set((state)=>({
+        likes:{...state.likes, [postId]:likes}
+    }))
+}))

--- a/libs/loginStore.ts
+++ b/libs/loginStore.ts
@@ -4,7 +4,9 @@ import { UserInfoProps } from "@/components/layouts/type";
 
 export const useLoggedIn = create<LoginState>(set => ({
     isLoggedIn: false,
+    isLoading: true,
     setIsLoggedIn: (loggedIn) => set({isLoggedIn: loggedIn}),
-    userInfo: undefined,
-    setUserInfo: (userInfo?: UserInfoProps) => set({userInfo})
+    userInfo: undefined as UserInfoProps | undefined,
+    setUserInfo: (userInfo?: UserInfoProps) => set({userInfo,isLoading: false}),
+    setLoading: (loading: boolean) => set({isLoading: loading})
 }))

--- a/libs/postStore.ts
+++ b/libs/postStore.ts
@@ -51,15 +51,15 @@ export const useCreatePostStore = create<CreatePostState>(set => ({
 }))
 
 export const usePostDataStore = create<PostDataState>(set => ({
-    postId: null,
+    postId: 0 ,
     postDetail: null,
     setPostId: postId => set({ postId }),
     setPostDetail: postDetail => set({ postDetail }),
 }))
 
 export const useUpdatePostDataStore = create<UpdatePostDataState>(set => ({
-    postId: null,
+    postId: 0,
     postDetail: null,
-    setPostId: postId => set({ postId }),
+    setPostId: (postId: number | null )=> set({ postId }),
     setPostDetail: postDetail => set({ postDetail }),
 }))

--- a/libs/type.ts
+++ b/libs/type.ts
@@ -33,16 +33,16 @@ export type CreatePostState = {
 }
 
 export type PostDataState = {
-    postId: string | null
+    postId: number | null
     postDetail: Post | null
-    setPostId: (postId: string | null) => void
+    setPostId: (postId: number | null) => void
     setPostDetail: (postDetail: Post | null) => void
 }
 
 export type UpdatePostDataState = {
-    postId: string | null
+    postId: number | null
     postDetail: UpdatePost | null
-    setPostId: (postId: string | null) => void
+    setPostId: (postId: number ) => void
     setPostDetail: (postDetail: UpdatePost | null) => void
 }
 

--- a/libs/type.ts
+++ b/libs/type.ts
@@ -95,6 +95,7 @@ export type ThemeState = {
 
 export type LoginState = {
     isLoggedIn: boolean
+    isLoading: boolean
     setIsLoggedIn: (isLoggedIn: boolean) => void
     userInfo: UserInfoProps | undefined
     setUserInfo: (userInfo: UserInfoProps) => void

--- a/types/post.ts
+++ b/types/post.ts
@@ -19,6 +19,7 @@ export type Post = {
     region: string
     address: string
     themeList: ThemeProps | ThemeProps[]
+    liked? :boolean
 }
 export type memosList = {
     shortPostId: number

--- a/types/post.ts
+++ b/types/post.ts
@@ -9,7 +9,7 @@ export type Post = {
     content: string | ""
     memos: memosList[] | []
     likeCount: number
-    likedMembersInfos?: likedMembersInfos[]
+    likedMembersInfos: likedMembersInfos[] 
     viewCount: number
     createdAt: string
     modifiedAt: string
@@ -19,7 +19,7 @@ export type Post = {
     region: string
     address: string
     themeList: ThemeProps | ThemeProps[]
-    liked? :boolean
+    hasLiked :boolean
 }
 export type memosList = {
     shortPostId: number


### PR DESCRIPTION
## 개요

플로팅바 좋아요 기능 수정

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details

- 디테일 포스트 좋아요 기능 api생성했습니다
[YG-129 💡refactor : detailPost 좋아요 api 생성](https://github.com/mobi-projects/yeogi-client/commit/300645cc9a9e2ad2a2e544c010ce01a610787008)

- 디테일 포스트 에서 좋아요 기능을 담당하는 handler 함수를 생성했습니다. 
(기존에 있던 코멘트 핸들러 함수를 사용하고싶었으나, api에서 받아오는 파라미터 명이 달라서 (postId , commentId) 실패했습니다..)
- like 기능 전역상태로 만들어서 comment부분에도 적용했습니다.
[YG-129 💡refactor : like handler함수 생성](https://github.com/mobi-projects/yeogi-client/commit/4b33d735a841386c9409434f4a6526b828d1e0d0) 


- ```libs``` 폴더에 있던 ```store.ts``` 파일명 -> ```postStore.ts```로 수정했습니다.
[Yg-129 🔖 Rename : post관련 전역상태파일 이름 수정](https://github.com/mobi-projects/yeogi-client/commit/37e7c1827d78711a9fe4289bc9a3f3bb2ee4a838)

### 결과
- 플로팅바 좋아요 기능 완

https://github.com/user-attachments/assets/ea4b241f-8cfc-4cd5-a244-37bcfa584ce9


- (이미 좋아요가 되어있는 게시글의 경우) 새로고침시 플로팅바 아이콘 active 상태로 변경

![스크린샷 2024-07-15 오전 12 39 43](https://github.com/user-attachments/assets/03308e43-eea9-439b-9112-051c7ccbe7a2)


오래걸려서 죄송합니다.. 플로팅바가 같이 껴있다보니 너무 어려웠..어요 ㅠㅜ

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```