### PR TITLE
YG-162 [refactor] : search re-render

### DIFF
--- a/app/(beforeLogin)/search/_components/filterTabs.tsx
+++ b/app/(beforeLogin)/search/_components/filterTabs.tsx
@@ -9,7 +9,7 @@ const FilterTabs = () => {
                     <div className="w-full overflow-x-auto">
                         <ContinentFilterTabs />
                     </div>
-                    <div className="w-full overflow-x-auto">
+                    <div className="w-full flex justify-center overflow-x-auto">
                         <ThemeFilterTabs />
                     </div>
                 </div>

--- a/app/(beforeLogin)/search/_components/postSection.tsx
+++ b/app/(beforeLogin)/search/_components/postSection.tsx
@@ -1,0 +1,23 @@
+import Pagination from "@/components/commons/pagination"
+import SortDropdown from "@/components/commons/sortDropdown"
+import dynamic from "next/dynamic"
+import { postSectionProps } from "./type"
+
+const PostSection = ({ filteredPosts, totalPages, currentPage, sortCondition }: postSectionProps) => {
+    const SearchResults = dynamic(() => import("@/components/commons/searchResults"), { ssr: false })
+
+    return (
+        <div>
+            <div className="w-full flex flex-col justify-center items-center">
+                <div className="w-full h-fit flex justify-between items-center">
+                    <h1 className="text-bg leading-[34px] font-semibold">게시물</h1>
+                    <SortDropdown initialValue={sortCondition} />
+                </div>
+                {filteredPosts && <SearchResults posts={filteredPosts} />}
+            </div>
+            {filteredPosts.length > 0 && <Pagination totalPages={totalPages} currentPage={currentPage} />}
+        </div>
+    )
+}
+PostSection.displayName = "PostSection"
+export default PostSection

--- a/app/(beforeLogin)/search/_components/postSection.tsx
+++ b/app/(beforeLogin)/search/_components/postSection.tsx
@@ -19,5 +19,4 @@ const PostSection = ({ filteredPosts, totalPages, currentPage, sortCondition }: 
         </div>
     )
 }
-PostSection.displayName = "PostSection"
 export default PostSection

--- a/app/(beforeLogin)/search/_components/themeFilter.tsx
+++ b/app/(beforeLogin)/search/_components/themeFilter.tsx
@@ -34,13 +34,13 @@ const ThemeFilterTabs = () => {
     }
 
     return (
-        <div className="max-w-[1228px] w-fit h-fit px-5 my-4 border-[1px] border-BRAND-50 rounded-full flex justify-center items-center">
+        <div className="max-w-[1228px] w-fit h-fit px-7 my-4 border-[1px] border-BRAND-50 rounded-full flex justify-center items-center">
             {ThemeEntries.map(([key, value], idx) => (
                 <Button
                     key={key}
                     onClick={() => handleThemeSelect(idx)}
                     textColor={selectedThemeIndex === idx ? "brand50" : "black"}
-                    className={`w-fit h-fit px-8 py-4 rounded bg-SYSTEM-beige text-sm leading-[27px] ${selectedThemeIndex === idx ? "font-semibold" : ""}`}
+                    className={`w-fit h-fit px-6 py-4 rounded bg-SYSTEM-beige text-sm leading-[27px] ${selectedThemeIndex === idx ? "font-semibold" : ""}`}
                 >
                     {value}
                 </Button>

--- a/app/(beforeLogin)/search/_components/type.ts
+++ b/app/(beforeLogin)/search/_components/type.ts
@@ -1,4 +1,14 @@
+import { Post } from "@/types/post"
+import { SortConditionType } from "@/types/sortCondition"
+
 export type FilterTabsProps = {
     selectedIndex: number | number[] | null
     setSelectedIndex: (selectedIndex: number) => void
+}
+
+export type postSectionProps = {
+    filteredPosts: Post[]
+    totalPages: number
+    currentPage: number
+    sortCondition: SortConditionType
 }

--- a/app/(beforeLogin)/search/page.tsx
+++ b/app/(beforeLogin)/search/page.tsx
@@ -78,11 +78,7 @@ const SearchPage = () => {
                     </div>
                     {filteredPosts && <SearchResults posts={paginationPosts} />}
                 </div>
-                {filteredPosts.length > 0 && (
-                    <div>
-                        <Pagination totalPages={totalPages} currentPage={currentPage} />
-                    </div>
-                )}
+                {filteredPosts.length > 0 && <Pagination totalPages={totalPages} currentPage={currentPage} />}
             </div>
         </div>
     )

--- a/app/_components/userRecommendation/realTimeRecommendation.tsx
+++ b/app/_components/userRecommendation/realTimeRecommendation.tsx
@@ -23,13 +23,15 @@ const RealTimeRecommendation = () => {
     const topPosts = posts?.slice(0, 3) || []
 
     return (
-        <div className="w-full overflow-x-auto flex justify-center items-center">
-            <div className="w-[1920px] pl-[120px] min-w-max flex justify-center items-center gap-[81px]">
-                {topPosts.map((top, index) => (
-                    <div key={index} className="w-[600px] flex justify-center">
-                        <RankCard topPosts={top} rank={ranks[index]} topPostId={top.postId} />
-                    </div>
-                ))}
+        <div className="w-full overflow-x-scroll flex 4xl:justify-center items-center justify-start">
+            <div className="max-w-[1920px] w-[1680px] flex justify-center items-center">
+                <div className="w-[1680px] flex justify-between items-center">
+                    {topPosts.map((top, index) => (
+                        <div key={index} className="flex justify-center">
+                            <RankCard topPosts={top} rank={ranks[index]} topPostId={top.postId} />
+                        </div>
+                    ))}
+                </div>
             </div>
         </div>
     )

--- a/components/commons/sortDropdown.tsx
+++ b/components/commons/sortDropdown.tsx
@@ -3,9 +3,9 @@
 import { useEffect, useState } from "react"
 import SortButton from "./sortButton"
 import Image from "next/image"
-import listIcon from "@/public/icons/list.svg"
 import { useRouter } from "next/navigation"
-import { isSortConditionType, SortConditionType, SortDropdownProps, sorts } from "@/types/sortCondition"
+import { isSortConditionType, SortConditionType, sorts } from "@/types/sortCondition"
+import { SortDropdownProps } from "./type"
 
 const SortDropdown = ({ initialValue = "RECENT" }: SortDropdownProps) => {
     const router = useRouter()
@@ -35,17 +35,16 @@ const SortDropdown = ({ initialValue = "RECENT" }: SortDropdownProps) => {
             <div>
                 <button
                     type="button"
-                    className=" text-xs inline-flex justify-center w-[120px] h-[44px] px-3 py-2.5 border rounded-[73px] text-GREY-80  border-GREY-80 focus:outline-none"
+                    className="text-xs inline-flex justify-center w-[120px] h-[44px] px-3 py-2.5 border rounded-[73px] text-GREY-80  border-GREY-80 focus:outline-none"
                     onClick={() => setIsOpen(!isOpen)}
                 >
-                    <Image src={listIcon} alt="list_Icon" width={24} height={24} className="w-[24px] h-[24px] mr-1" />
+                    <Image src={"/icons/list.svg"} alt="sort lists" width={24} height={24} className="w-6 h-6 mr-1" />
                     {sorts.find(sort => sort.key === activeSort)?.label}
                 </button>
             </div>
-
             {isOpen && (
-                <div className=" border rounded-3xl py-3 w-[140px] h-[148px] bg-SYSTEM-white absolute shadow-lg  focus:outline-none">
-                    <div className=" items-center text-center ">
+                <div className="border rounded-3xl py-3 w-[140px] h-[148px] bg-SYSTEM-white absolute shadow-lg focus:outline-none">
+                    <div className="items-center text-center">
                         {sorts.map((sort, index) => (
                             <SortButton
                                 key={sort.key}

--- a/components/commons/sortDropdown.tsx
+++ b/components/commons/sortDropdown.tsx
@@ -5,22 +5,22 @@ import SortButton from "./sortButton"
 import Image from "next/image"
 import listIcon from "@/public/icons/list.svg"
 import { useRouter } from "next/navigation"
-import { sorts } from "@/constants/sorts"
+import { isSortConditionType, SortConditionType, SortDropdownProps, sorts } from "@/types/sortCondition"
 
-const SortDropdown = () => {
+const SortDropdown = ({ initialValue = "RECENT" }: SortDropdownProps) => {
     const router = useRouter()
     const [isOpen, setIsOpen] = useState(false)
-    const [activeSort, setActiveSort] = useState("RECENT")
+    const [activeSort, setActiveSort] = useState(initialValue)
 
     useEffect(() => {
         const params = new URLSearchParams(window.location.search)
         const sort = params.get("sortCondition")
-        if (sort && sorts.some(s => s.key === sort)) {
+        if (sort && isSortConditionType(sort)) {
             setActiveSort(sort)
         }
     }, [])
 
-    const handleSortClick = (key: string) => {
+    const handleSortClick = (key: SortConditionType) => {
         setActiveSort(key)
         setIsOpen(false)
 
@@ -51,7 +51,7 @@ const SortDropdown = () => {
                                 key={sort.key}
                                 label={sort.label}
                                 isActive={activeSort === sort.key}
-                                onClick={() => handleSortClick(sort.key)}
+                                onClick={() => isSortConditionType(sort.key) && handleSortClick(sort.key)}
                                 showBorder={index === 1}
                             />
                         ))}

--- a/components/commons/type.ts
+++ b/components/commons/type.ts
@@ -5,6 +5,7 @@ import { ChangeEventHandler, ButtonHTMLAttributes, ReactNode, FormEvent } from "
 import { VariantProps } from "class-variance-authority"
 import { buttonStyle } from "@/styles/common-button"
 import { Post } from "@/types/post"
+import { SortConditionType } from "@/types/sortCondition"
 
 export type PostCardProps = {
     post_id: number
@@ -68,6 +69,10 @@ export type SortButtonProps = {
     isActive: boolean
     onClick: () => void
     showBorder: boolean
+}
+
+export type SortDropdownProps = {
+    initialValue?: SortConditionType
 }
 
 export type SearchBarProps = {

--- a/constants/sorts.ts
+++ b/constants/sorts.ts
@@ -1,5 +1,0 @@
-export const sorts = [
-    { key: "RECENT", label: "최신 순" },
-    { key: "LIKES", label: "좋아요 순" },
-    { key: "VIEWS", label: "조회 순" },
-]

--- a/types/sortCondition.ts
+++ b/types/sortCondition.ts
@@ -5,16 +5,13 @@ export type Sort = {
 
 export type SortConditionType = "LIKES" | "VIEWS" | "RECENT"
 
-export type SortDropdownProps = {
-    initialValue?: SortConditionType
-}
-
 export const sorts: Sort[] = [
     { key: "RECENT", label: "최신순" },
     { key: "VIEWS", label: "조회순" },
     { key: "LIKES", label: "좋아요순" },
 ]
 
+// type guard function
 export const isSortConditionType = (value: string): value is SortConditionType => {
     return ["RECENT", "VIEWS", "LIKES"].includes(value)
 }

--- a/types/sortCondition.ts
+++ b/types/sortCondition.ts
@@ -1,1 +1,20 @@
+export type Sort = {
+    key: string
+    label: string
+}
+
 export type SortConditionType = "LIKES" | "VIEWS" | "RECENT"
+
+export type SortDropdownProps = {
+    initialValue?: SortConditionType
+}
+
+export const sorts: Sort[] = [
+    { key: "RECENT", label: "최신순" },
+    { key: "VIEWS", label: "조회순" },
+    { key: "LIKES", label: "좋아요순" },
+]
+
+export const isSortConditionType = (value: string): value is SortConditionType => {
+    return ["RECENT", "VIEWS", "LIKES"].includes(value)
+}


### PR DESCRIPTION
## 개요

<!-- 한 줄 요약 -->
- [YG-162 🎁 #open #comment top-posts 반응형 변경](https://github.com/mobi-projects/yeogi-client/commit/bdbf1c6704531fec855ac689180901ce6d36a10c)
- [YG-162 🟢 #close #comment 메모이제이션으로 리렌더링 범위 좁히기](https://github.com/mobi-projects/yeogi-client/commit/97c8f8c645c0338f2834ae7d05e2509a304edcca)

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
<!-- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!-- 직접 만든 함수가 있다면 예제를 만들어 상세히 설명해주세요. (코드 캡쳐) -->

###### [YG-162 🎁 #open #comment top-posts 반응형 변경](https://github.com/mobi-projects/yeogi-client/commit/bdbf1c6704531fec855ac689180901ce6d36a10c)

사이즈가 큰 화면에서도 `overflow-x-auto`가 되어 있어 스크롤이 되지만 깨져보인다는 피드백이 있었습니다.
큰 화면에서는 잘리는 부분 없이 보이도록 변경했습니다.


<img width="1690" src="https://github.com/user-attachments/assets/78b129bb-d1f4-4fc9-8e62-0d5437bf64cf">


화면이 점점 작아졌을 때의 모습입니다 :

https://github.com/user-attachments/assets/1c53234c-f720-4c39-8402-2d267bc76e36


작은 화면에서는 이전과 동일하게 좌우 스크롤이 가능합니다.

https://github.com/user-attachments/assets/62a8d6b7-febc-439e-baf2-d44cb4ff554d


<br />

###### [YG-162 🟢 #close #comment 메모이제이션으로 리렌더링 범위 좁히기](https://github.com/mobi-projects/yeogi-client/commit/97c8f8c645c0338f2834ae7d05e2509a304edcca)

- 게시물의 필터를 바꿧는데 전체 페이지가 리렌더링 되고 있습니다. 해당 섹션만 리렌더링 되면 좋을것 같아요
- 게시물의 페이지네이션도 마찬가지로 전체 페이지가 리렌더링 되고 있습니다.


`useMemo`와 `useCallback`를 사용해 메모이제이션으로 위 피드백에 대한 내용 수정했습니다.

- useMemo : 메모이제이션된 값을 반환
- useCallback : 메모이제이션된 콜백을 반환

<br />

##### 메모이제이션(memoization)이란?

메모이제이션은 동일한 계산을 반복해야 할 때 이전에 계산했던 값들을 메모리에 저장함으로써 동일한 계산의 반복 수행을 제거하여 프로그램 실행 속도를 빠르게 할 수 있는 방법입니다.
동적 계획법의 핵심이 되는 기술입니다.

<br />

##### 메모이제이션의 장점

1️⃣ 성능 최적화
불필요한 재계산을 방지하여 애플리케이션의 성능을 향상시킵니다.

2️⃣ 렌더링 최적화
특히 useCallback을 사용할 때, 자식 컴포넌트의 불필요한 리렌더링을 방지할 수 있습니다.

3️⃣ 일관성
동일한 입력에 대해 항상 동일한 결과를 보장합니다.

<br />

##### 메모이제이션(memoization)의 주의할 점

1️⃣ 과도한 사용
모든 것을 메모이제이션할 필요는 없습니다. 계산 비용이 크거나, 자주 리렌더링되는 컴포넌트에서 주로 사용하세요.

2️⃣ 의존성 배열
의존성 배열을 잘못 설정하면 오히려 버그를 유발할 수 있습니다. 필요한 모든 의존성을 포함해야 합니다.

3️⃣ 메모리 사용
메모이제이션은 결과를 메모리에 저장하므로, 너무 많이 사용하면 메모리 사용량이 증가할 수 있습니다.


<br />

##### 요약

메모이제이션을 적절히 사용하면 React 애플리케이션의 성능을 크게 향상시킬 수 있습니다. 
하지만 항상 성능 측정을 통해 실제로 이점이 있는지 확인하는 것이 좋습니다.


<br />

##### 🔗 좋아보이는 메모이제이션 관련 사이트 링크

- [Next.js 캐싱으로 웹 서버 성능 최적화](https://fe-developers.kakaoent.com/2024/240418-optimizing-nextjs-cache/)
- [Caching in Next.js(Request Memoization, Data Cache)](https://medium.com/@z22857744/caching-in-next-js-request-memoization-data-cache-9bde28f2652a)
- [React/Next.js Performance Optimization Explained: Navigating Through Memoization’s Complexity Maze](https://medium.com/@woywro/react-next-js-performance-optimization-explained-navigating-through-memoizations-complexity-maze-daafba63c318)

<br />

1️⃣ useMemo

일단 먼저 useMemo를 사용해서 filteredPosts와 totalPages를 메모이제이션하여 불필요한 재계산을 방지합니다.

```javascript
const filteredPosts = useMemo(() => {
    if (!mutationData) return []
    let results = filterPosts(mutationData, searchKeyword)
    if (searchTheme) {
        results = results.filter(post =>
            Array.isArray(post.themeList)
                ? post.themeList.includes(searchTheme as ThemeKeys)
                : post.themeList === searchTheme,
        )
    }
    if (searchContinent) {
        results = results.filter(post => post.continent === searchContinent)
    }
    return results
}, [mutationData, searchKeyword, searchTheme, searchContinent])
```

filteredPosts는 의존성 배열 안의 값들 (mutationData, searchKeyword, searchTheme, searchContinent) 중 하나라도 변경될 때만 재계산됩니다!

```javascript
const totalPages = useMemo(() => Math.ceil(filteredPosts.length / ITEMS_PER_PAGE), [filteredPosts.length])
```


그리고 PostSection을 별도의 컴포넌트로 분리해 게시물 관련 변경사항이 있을 때만 이 부분이 리렌더링되도록 했습니다.
분리한 PostSection 컴포넌트를 memo로 감싸 props가 변경되지 않으면 리렌더링되지 않도록 했습니다.

```javascript
const PostSection = dynamic(() => import("./_components/postSection"), { ssr: false })
```

2️⃣ useCallback

이 함수도 의존성 배열에 담긴 값 (filteredPosts)이 변경될 때만 렌더링이 되도록 변경했습니다.

```javascript
const paginationPosts = useCallback(
    (page: number) => filteredPosts.slice((page - 1) * ITEMS_PER_PAGE, page * ITEMS_PER_PAGE),
    [filteredPosts],
)
```

<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```