### PR TITLE
YG-175 [refactor] : responsive header

### DIFF
--- a/components/layouts/_components/headerLogin.tsx
+++ b/components/layouts/_components/headerLogin.tsx
@@ -68,7 +68,7 @@ const HeaderLogin = ({ isShowHeader }: HeaderLoginProps) => {
                             alt="게시글 작성하기"
                             className="w-6 h-6 md:mr-2 mr-0"
                         />
-                        <span className="hidden md:inline">글쓰기</span>
+                        <span className="hidden md:inline md:whitespace-nowrap md:visible invisible">글쓰기</span>
                     </Button>
                 </>
             ) : (

--- a/components/layouts/_components/userDialog.tsx
+++ b/components/layouts/_components/userDialog.tsx
@@ -17,7 +17,7 @@ const UserDialog = ({ userId, setIsProfileClicked }: UserDialogProps) => {
     }
 
     return (
-        <div className="absolute top-20 5xl:right-[190px] max-[2000px]:right-[20%] min-[2001px]:right-[11%] min-[2100px]:right-[13%] min-[2200px]:right-[15%] min-[2300px]:right-[16%] w-[150px] h-[105px] bg-SYSTEM-white rounded-3xl shadow-custom p-2 flex flex-col justify-evenly items-center text-xs">
+        <div className="absolute top-20 w-[150px] h-[105px] bg-SYSTEM-white rounded-3xl shadow-custom p-2 flex flex-col justify-evenly items-center text-xs">
             <div onClick={navigateMypage} className="cursor-pointer">
                 <p>마이페이지</p>
             </div>


### PR DESCRIPTION
## 개요

#### header 에 글쓰기 버튼 및 userDialog 쪽 위치 수정했습니다

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details
- userDialog 컴포넌트 위치 수정했습니다. md로 나눠져있는거 다 삭제하니까 오히려.. 잘 되더라고요,,? 아마도 md로 반응형을 세세하게 나눠서 지정되지않은 px에서 반응형위치가 잘못되는것같습니다.
삭제하여 반응형으로 위치가 일정하게 나오게끔 수정했습니다.

https://github.com/user-attachments/assets/4a116b9b-4b1b-4bca-b904-cd642b68e7b3



- 설문 회고에서 문제가 되었던 버튼 글씨 2줄로 나오는 반응형 문제점도 수정했습니다.
- 980px~ 버튼의 글씨가 2줄로 나오는 이슈가 있었는데,
```tsx
 <span className="hidden md:inline md:whitespace-nowrap md:visible invisible">글쓰기</span>
```
위와 같은 style 코드 추가하여 수정했습니다.

https://github.com/user-attachments/assets/4e83b467-1c6b-496c-8022-4e9206de393b


## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```