### PR TITLE
YG-190 [refactor] : optimization

### DIFF
--- a/app/_components/polaroid.tsx
+++ b/app/_components/polaroid.tsx
@@ -49,7 +49,7 @@ const Polaroid = ({
             />
             <div className="w-full flex flex-col items-start pl-2.5">
                 <p className="pt-4 pb-2 sm:pl-4 text-sm xl:text-xs md:text-xxs font-bold">{step}</p>
-                <p className="w-[200px] md:w-[240px sm:pl-4 text-bg xl:text-sm md:text-xxsfont-semibold break-keep">
+                <p className="w-[200px] md:w-[240px] sm:pl-4 text-bg xl:text-sm md:text-xxsfont-semibold break-keep">
                     {description} <span className={textColor}>{spanText}</span>.
                 </p>
             </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,12 +4,11 @@
 
 /* fonts */
 .font-myeongjo {
-  font-family: 'Nanum Myeongjo', serif;
+  font-family: var(--font-myeongjo), serif;
 }
 .font-pretendard {
-  font-family: 'Pretendard', sans-serif;
+  font-family: var(--font-pretendard), sans-serif;
 }
-
 body {
   width: 100%;
   height: 100%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import Layout from "@/components/layouts/layout"
 import { ReactQueryProvider } from "@/components/queryProvider"
 import ClientLayout from "./clientLayout"
 
-const myeongjo = Nanum_Myeongjo({ weight: ["400", "700"], subsets: ["latin"] })
+const myeongjo = Nanum_Myeongjo({ weight: ["400", "700"], subsets: ["latin"], variable: "--font-myeongjo" })
 const pretendard = localFont({
     src: [
         {
@@ -35,6 +35,7 @@ const pretendard = localFont({
             style: "normal",
         },
     ],
+    variable: "--font-pretendard",
 })
 
 export const metadata: Metadata = {
@@ -63,7 +64,7 @@ export default function RootLayout({
                     defer
                 />
             </head>
-            <body className={`${myeongjo.className} ${pretendard.className}`}>
+            <body className={`${myeongjo.variable} ${pretendard.variable}`}>
                 <ReactQueryProvider>
                     <ClientLayout>
                         <Layout>{children}</Layout>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import MainRecommend from "./_components/mainRecommend"
 import MainSurveyRecommend from "./_components/mainSurveyRecommend"
 import MainThemeBanner from "./_components/mainThemeBanner"
 
+/////
 const Home = () => {
     return (
         <main className="w-full flex justify-center items-center flex-col overflow-x-hidden">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,6 @@ import MainRecommend from "./_components/mainRecommend"
 import MainSurveyRecommend from "./_components/mainSurveyRecommend"
 import MainThemeBanner from "./_components/mainThemeBanner"
 
-/////
 const Home = () => {
     return (
         <main className="w-full flex justify-center items-center flex-col overflow-x-hidden">

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,7 @@ const nextConfig = {
             "ssl.pstatic.net",
             "k.kakaocdn.net",
             "t1.kakaocdn.net",
+            "yeogi-bucket.s3.ap-northeast-2.amazonaws.com",
         ],
     },
     async rewrites() {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -43,6 +43,15 @@ const nextConfig = {
         ]
     },
     reactStrictMode: false,
+    webpack: (config, { dev, isServer }) => {
+        // 개발 환경에서만 React Developer Tools를 포함시키는 로직.
+        if (!dev && !isServer) {
+            config.plugins = config.plugins.filter(plugin => {
+                return plugin.constructor.name !== "ReactDevToolsPlugin"
+            })
+        }
+        return config
+    },
 }
 
 export default nextConfig

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -14,6 +14,10 @@ const config: Config = {
             colors: {
                 ...COLORS,
             },
+            fontFamily: {
+                myeongjo: ["var(--font-myeongjo)", "serif"],
+                pretendard: ["var(--font-pretendard)", "sans-serif"],
+            },
             fontSize: {
                 ...FONT_SIZE,
             },


### PR DESCRIPTION
## 개요

불필요한 코드를 삭제하고, 배포된 페이지 기준으로 성능 저하되는 부분을 개선했습니다.

<br/>

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

-   [x] PR 제목 및 커밋 메시지 컨벤션 확인
-   [x] 직접 만든 함수가 있다면 이에 대한 설명 추가 (ex. JS DOCS)
-   [x] 변경 사항에 대한 테스트 완료 (버그 수정/기능에 대한 테스트)
-   [x] Label 확인
-   [x] Assignees 설정 확인
-   [x] Reviewers 설정 확인

<br/>

## PR details

#### 1. SVG, WebP
초반 작업 중, 크기가 클것이라고 생각된 SVG -> WebP로 바꾸는것이 성능 최적화 면에서 좋을것이라 생각 되어 SVG를 WebP 로 변경 했었는데, 오히려 성능 최적화 점수가 떨어지는 이슈가 발생했습니다.

SVG와 WebP는 서로 다른 특성을 가진 이미지 포맷으로 ,  SVG를 WebP 로 변환하는것이 꼭 좋은 방향이 아니라고 합니다.
(다들 아시겠지만,,, 간단히 정리 해보겠습니다) 

> 🟢 SVG:
> 수학적 정의로 도형을 그리기 때문에 크기를 조절해도 해상도에 영향을 받지 않습니다.따라서 이미지가 선명하게 유지됩니다.
> 용도: 로고, 아이콘, UI 요소 등에서 자주 사용됩니다. 텍스트와 도형이 포함된 디자인에 적합합니다.
> 파일 크기: 간단한 도형과 아이콘의 경우, SVG는 파일 크기가 매우 작을 수 있습니다.

> 🟢 WebP:
> 픽셀 기반입니다. 이로 인해 이미지의 품질은 원본 해상도에 따라 달라질 수 있습니다. ==> 제가 바꾸려고 했던 SVG이미지 Travel01 ("/images/main-01.svg") 의 경우 실제로 네트워크 페이로드가 크다고 경고받아 WebP로 바꾸는것이 좋지만, 원본 사진과 달라져서 그냥 두었습니다. (밑에 사진에서 나오는 svg 파일 두개 다 원본 사진과 달라지는 이슈가 있어 변경하지 못했습니다.)
> ![image](https://github.com/user-attachments/assets/89dd172a-fbd3-4b76-afd7-367e9051e230)
> 용도: 사진과 같은 복잡한 이미지를 압축하는 데 적합하며, PNG와 JPEG의 장점을 결합하여 더 작은 파일 크기로 고품질 이미지를 제공합니다.

#### 2. 애플리케이션이 실행될 때 react_devtools_backend_compact.js 파일이 로드되는 문제 개선

Light House 점수 개선을 위하여 확인하다가, react_devtools가 계속해서 실행되고있는 점을 확인했습니다.

![image](https://github.com/user-attachments/assets/9e09e56f-e9f9-461d-9f48-7651e82d71cc)

> 🔴 React-Dev-Tools :
> 주로 개발자가 React 애플리케이션을 디버깅하거나 상태를 분석할 때 사용됩니다.
> 사용자에게 제공되는 애플리케이션에서 이 파일이 로드될 필요가 없으며, 오히려 성능에 영향을 줄 수 있습니다.

실제로 화면에서와 같이 "사용하지 않는 CSS 줄이기 " 라는 메세지와 함께  실제 사용자에게는 필요하지 않기 때문에 이를 제거하거나 로드되지 않도록 최적화할 필요가 있다고 보여지고있습니다.

이를 해결하기위해 프로덕션 모드로 빌드되게끔 수정하였습니다.
> - 애플리케이션을 프로덕션 모드로 빌드하기
> 아래 코드 처럼 설정하면 , 개발자 도구와 관련된 코드들이 자동으로 제거되거나, 로드되지 않게 할수있다고 합니다.
> ```tsx
> //next.config.mjs
>     webpack: (config, { dev, isServer }) => {
>        // 개발 환경에서만 React Developer Tools를 포함시키는 로직.
>        if (!dev && !isServer) {
>            config.plugins = config.plugins.filter(plugin => {
>                return plugin.constructor.name !== "ReactDevToolsPlugin"
>            })
>        }
>        return config
>    },
> ```



#### 3. 불필요한 폰트가 계속 사용되고있는 문제 개선

배포페이지에서 사용되지 않은 css가 무엇인지 확인하는 중, 네트워크 창을 통해 폰트 쪽에서 문제가 있음을 발견하였습니다.

![image](https://github.com/user-attachments/assets/ea60ff30-0e32-4003-a7c1-ca402daad62a)
![image](https://github.com/user-attachments/assets/ee7faaa0-df95-42c6-a10d-9fa9310e8973)

NextJS에서는 PurgeCSS 를 통해 불필요한 css를 제거하는게 일반적이라고 합니다.

> 🔸PurgeCSS :
> 실제로 사용되지 않는 CSS 클래스를 자동으로 찾아 제거하는 역할을 합니다. -> 성능 개선 가능!
> 불필요한 CSS가 제거되어 최종 CSS 파일의 크기를 줄일 수 있습니다. -> 최적화 가능!

**BUT!** 저희는 현재 **TailwindCSS를 사용**하고있고, Tailwind에서는 **내부적으로 purge 옵션을 제공**하여 사용되지 않는 CSS를 제거할 수 있습니다. 즉, 이미 진작에 css 최적화가 일어나고 있다는 것이죠..😞 (과거에는 'purge' 라는 명칭으로 설정하였지만 'content' 로 이름이 변경되었습니다.) tailWindConfig 파일에서도 저희가 잘 설정을 해놓았더라구요

근데도 왜 안되는지 살펴보았는데,, 

> 🧐 왜 안되나?!
> Tailwind CSS는 기본적으로 사용되지 않는 CSS를 제거하는 기능을 제공하지만, @font-face 규칙처럼 폰트와 관련된 CSS는 Tailwind CSS의 Purge 기능의 적용 범위에 포함되지 않습니다. 폰트와 관련된 CSS는 보통 폰트 파일을 로드할 때 사용되며, 이런 경우에는 몇 가지 다른 접근 방법이 필요할 수 있습니다.

라는 답변을 얻었습니다.

이를 해결하기위해 폰트 부분에서 몇가지 설정을 수정하였습니다. 아직 배포되기 전이므로 배포된 이후에 해당 문제점이 개선되길 바래봅니다 ㅠㅜ (문제가 생길경우 다시 수정해보겠습니다. 현재 로컬에서의 build가 문제 없음을 확인하였습니다.)

> Nanum_Myeongjo와 localFont(Pretendard) 설정에 variable 속성 및 최적화된 폰트 패밀리 추가
> 이러한 변경으로 Next.js의 내장 폰트 최적화 기능을 더 효과적으로 활용할 수 있다고 합니다. --> 즉, CSS 변수를 통해 전역적으로 사용 가능하며, 필요한 경우에만 로드되게끔 해준다네요!

> ```tsx
>//layoout.tsx
> const myeongjo = Nanum_Myeongjo({ weight: ["400", "700"], subsets: ["latin"], variable: "--font-myeongjo" })    
>      
>//global.css      
>.font-myeongjo {
>  font-family: var(--font-myeongjo), serif;
> }
> .font-pretendard {
>  font-family: var(--font-pretendard), sans-serif;
> }            
>             
> //  tailwind.config.ts        
> theme: {
>  extend: {
>    fontFamily: {
>     myeongjo: ['var(--font-myeongjo)', 'serif'],
>      pretendard: ['var(--font-pretendard)', 'sans-serif'],
>    },
>    // ... 기존 설정들
>  },
> },        
> ```




<br/>

## When modifying code...

```text
# Request Level
  - [ ] : "🔥 이대로 Merge 하면 안돼요~!"
  - [ ] : "🥹 고치면 분명 나아질 게 분명합니다.."
  - [ ] : "🤷 수정하면 좋지 않을까요?"

# Description

```